### PR TITLE
StartConfiguration changes

### DIFF
--- a/NightgamesMod/nightgames/Resources/ResourceLoader.java
+++ b/NightgamesMod/nightgames/Resources/ResourceLoader.java
@@ -37,15 +37,19 @@ public class ResourceLoader {
     public static InputStream getFileResourceAsStream(String path) {
         // first check in the working directory
         File f = new File(path);
+        return getFileResourceAsStream(f);
+    }
+
+    public static InputStream getFileResourceAsStream(File f) {
         try {
             InputStream res = new FileInputStream(f);
             return res;
         } catch (FileNotFoundException e) {
-            System.err.println("Could not find file " + path);
+            System.err.println("Could not find file " + f.getPath());
             e.printStackTrace();
             System.err.println("Current active directory is " + System.getProperty("user.dir"));
         }
         // then check in the class directory
-        return ResourceLoader.class.getClassLoader().getResourceAsStream("resources/" + path);
+        return ResourceLoader.class.getClassLoader().getResourceAsStream("resources/" + f.getPath());
     }
 }

--- a/NightgamesMod/nightgames/characters/Airi.java
+++ b/NightgamesMod/nightgames/characters/Airi.java
@@ -14,6 +14,7 @@ import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
 import nightgames.skills.Skill;
+import nightgames.start.NpcConfiguration;
 import nightgames.status.SlimeMimicry;
 import nightgames.status.Stsflag;
 
@@ -24,7 +25,15 @@ public class Airi extends BasePersonality {
     private static final long serialVersionUID = -8169646189131720872L;
 
     public Airi() {
-        super("Airi", 10);
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public Airi(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Airi", 10, charConfig, commonConfig);
+
+    }
+
+    @Override protected void applyBasicStats() {
         character.change();
         character.setTrophy(Item.AiriTrophy);
         preferredCockMod = CockMod.slimy;
@@ -55,7 +64,7 @@ public class Airi extends BasePersonality {
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.b);
         character.body.add(PussyPart.normal);
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/Airi.java
+++ b/NightgamesMod/nightgames/characters/Airi.java
@@ -62,8 +62,6 @@ public class Airi extends BasePersonality {
 
         character.plan = Plan.retreating;
         character.mood = Emotion.confident;
-        character.body.add(BreastsPart.b);
-        character.body.add(PussyPart.normal);
         character.initialGender = CharacterSex.female;
     }
 

--- a/NightgamesMod/nightgames/characters/Angel.java
+++ b/NightgamesMod/nightgames/characters/Angel.java
@@ -29,6 +29,7 @@ public class Angel extends BasePersonality {
     }
 
     protected void applyBasicStats() {
+        character.isStartCharacter = true;
         preferredCockMod = CockMod.blessed;
         character.outfitPlan.add(Clothing.getByID("Tshirt"));
         character.outfitPlan.add(Clothing.getByID("bra"));

--- a/NightgamesMod/nightgames/characters/Angel.java
+++ b/NightgamesMod/nightgames/characters/Angel.java
@@ -49,7 +49,6 @@ public class Angel extends BasePersonality {
         character.body.add(BreastsPart.dd);
         // very feminine face
         character.body.add(new FacePart(.1, 4.2));
-        character.body.add(PussyPart.normal);
         character.initialGender = CharacterSex.female;
     }
 

--- a/NightgamesMod/nightgames/characters/BasePersonality.java
+++ b/NightgamesMod/nightgames/characters/BasePersonality.java
@@ -23,6 +23,7 @@ import nightgames.global.Flag;
 import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.skills.Skill;
+import nightgames.start.NpcConfiguration;
 
 public abstract class BasePersonality implements Personality {
     /**
@@ -40,20 +41,46 @@ public abstract class BasePersonality implements Personality {
         Optional<Attribute> getPreferred(Character c);
     }
 
-    public BasePersonality(String name, int level) {
+    protected BasePersonality() {
+    }
+
+    public BasePersonality(String name, int level, Optional<NpcConfiguration> charConfig,
+                    Optional<NpcConfiguration> commonConfig) {
+        // Make the built-in character
         type = getClass().getSimpleName();
-        this.character = new NPC(name, level, this);
+        character = new NPC(name, level, this);
+        applyBasicStats();
         growth = new Growth();
         preferredCockMod = CockMod.error;
         preferredAttributes = new ArrayList<PreferredAttribute>();
         setGrowth();
+
+        // Apply config changes
+        applyConfigStats(commonConfig);
+        applyConfigStats(charConfig);
+
+        character.body.finishBody(character.initialGender);
+    }
+
+    /**
+     * Apply built-in character stats. Can be later overridden by StartConfiguration.
+     */
+    // TODO: Make this data-driven, like with custom NPCs.
+    protected abstract void applyBasicStats();
+
+    /**
+     * Apply character stats overrides from StartConfiguration.
+     * @param cfg NpcConfiguration extracted from a StartConfiguration.
+     */
+    protected void applyConfigStats(Optional<NpcConfiguration> cfg) {
+        cfg.ifPresent(c -> c.apply(character));
     }
     
     public void setCharacter(NPC c) {
         this.character = c;
     }
 
-    public void setGrowth() {}
+    abstract public void setGrowth();
 
     @Override
     public void rest(int time) {

--- a/NightgamesMod/nightgames/characters/BasePersonality.java
+++ b/NightgamesMod/nightgames/characters/BasePersonality.java
@@ -54,10 +54,11 @@ public abstract class BasePersonality implements Personality {
         preferredCockMod = CockMod.error;
         preferredAttributes = new ArrayList<PreferredAttribute>();
         setGrowth();
+        character.body.makeGenitalOrgans(character.initialGender);
 
         // Apply config changes
-        applyConfigStats(commonConfig);
-        applyConfigStats(charConfig);
+        Optional<NpcConfiguration> mergedConfig = NpcConfiguration.mergeOptionalNpcConfigs(charConfig, commonConfig);
+        mergedConfig.ifPresent(cfg -> cfg.apply(character));
 
         character.body.finishBody(character.initialGender);
     }
@@ -67,14 +68,6 @@ public abstract class BasePersonality implements Personality {
      */
     // TODO: Make this data-driven, like with custom NPCs.
     protected abstract void applyBasicStats();
-
-    /**
-     * Apply character stats overrides from StartConfiguration.
-     * @param cfg NpcConfiguration extracted from a StartConfiguration.
-     */
-    protected void applyConfigStats(Optional<NpcConfiguration> cfg) {
-        cfg.ifPresent(c -> c.apply(character));
-    }
     
     public void setCharacter(NPC c) {
         this.character = c;

--- a/NightgamesMod/nightgames/characters/Cassie.java
+++ b/NightgamesMod/nightgames/characters/Cassie.java
@@ -58,7 +58,6 @@ public class Cassie extends BasePersonality {
         character.plan = Plan.hunting;
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.c);
-        character.body.add(PussyPart.normal);
         character.initialGender = CharacterSex.female;
     }
 

--- a/NightgamesMod/nightgames/characters/Cassie.java
+++ b/NightgamesMod/nightgames/characters/Cassie.java
@@ -17,6 +17,7 @@ import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
 import nightgames.stance.Stance;
+import nightgames.start.NpcConfiguration;
 import nightgames.status.Energized;
 
 public class Cassie extends BasePersonality {
@@ -26,7 +27,14 @@ public class Cassie extends BasePersonality {
     private static final long serialVersionUID = 8601852023164119671L;
 
     public Cassie() {
-        super("Cassie", 1);
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public Cassie(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Cassie", 1, charConfig, commonConfig);
+    }
+
+    protected void applyBasicStats() {
         preferredCockMod = CockMod.runic;
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("blouse"));
@@ -50,7 +58,7 @@ public class Cassie extends BasePersonality {
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.c);
         character.body.add(PussyPart.normal);
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/Cassie.java
+++ b/NightgamesMod/nightgames/characters/Cassie.java
@@ -35,6 +35,7 @@ public class Cassie extends BasePersonality {
     }
 
     protected void applyBasicStats() {
+        character.isStartCharacter = true;
         preferredCockMod = CockMod.runic;
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("blouse"));

--- a/NightgamesMod/nightgames/characters/Character.java
+++ b/NightgamesMod/nightgames/characters/Character.java
@@ -1525,7 +1525,8 @@ public abstract class Character extends Observable implements Cloneable {
             c.write(this, orgasmLiner);
             c.write(opponent, opponentOrgasmLiner);
         }
-        if (human()) {
+        // TODO: If NPCs are able to acquire long term addictions, replace this check with a call to human().
+        if (this instanceof Player) {
             Player p = (Player) this;
             
             if (p.checkAddiction(AddictionType.CORRUPTION, opponent) 

--- a/NightgamesMod/nightgames/characters/Character.java
+++ b/NightgamesMod/nightgames/characters/Character.java
@@ -68,6 +68,7 @@ public abstract class Character extends Observable implements Cloneable {
      *
      */
     public String name;
+    public CharacterSex initialGender;
     public int level;
     public int xp;
     public int rank;

--- a/NightgamesMod/nightgames/characters/CharacterSex.java
+++ b/NightgamesMod/nightgames/characters/CharacterSex.java
@@ -1,5 +1,6 @@
 package nightgames.characters;
 
+import nightgames.characters.body.Body;
 import nightgames.global.Global;
 
 public enum CharacterSex {
@@ -13,6 +14,16 @@ public enum CharacterSex {
     CharacterSex(String desc) {
         this.desc = desc;
     }
+
+    public boolean hasPussy() {
+        return this == female || this == herm;
+    }
+
+    public boolean hasCock() {
+        return this == male || this == herm;
+    }
+
+
 
     @Override
     public String toString() {

--- a/NightgamesMod/nightgames/characters/Eve.java
+++ b/NightgamesMod/nightgames/characters/Eve.java
@@ -12,6 +12,7 @@ import nightgames.combat.Result;
 import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
+import nightgames.start.NpcConfiguration;
 
 public class Eve extends BasePersonality {
     /**
@@ -20,8 +21,14 @@ public class Eve extends BasePersonality {
     private static final long serialVersionUID = -8169646189131720872L;
 
     public Eve() {
-        super("Eve", 10);
+        this(Optional.empty(), Optional.empty());
+    }
 
+    public Eve(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Eve", 10, charConfig, commonConfig);
+    }
+
+    protected void applyBasicStats() {
         character.outfitPlan.add(Clothing.getByID("tanktop"));
         character.outfitPlan.add(Clothing.getByID("crotchlesspanties"));
         character.outfitPlan.add(Clothing.getByID("jeans"));
@@ -48,7 +55,7 @@ public class Eve extends BasePersonality {
         character.body.add(PussyPart.normal);
         // somewhat androgynous face
         character.body.add(new FacePart(.1, .9));
-        character.body.finishBody(CharacterSex.herm);
+        character.initialGender = CharacterSex.herm;
         preferredCockMod = CockMod.primal;
     }
 

--- a/NightgamesMod/nightgames/characters/Jewel.java
+++ b/NightgamesMod/nightgames/characters/Jewel.java
@@ -31,6 +31,7 @@ public class Jewel extends BasePersonality {
     }
 
     protected void applyBasicStats() {
+        character.isStartCharacter = true;
         preferredCockMod = CockMod.enlightened;
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("tanktop"));

--- a/NightgamesMod/nightgames/characters/Jewel.java
+++ b/NightgamesMod/nightgames/characters/Jewel.java
@@ -51,7 +51,6 @@ public class Jewel extends BasePersonality {
         character.plan = Plan.hunting;
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.c);
-        character.body.add(PussyPart.normal);
         // fairly feminine face
         character.body.add(new FacePart(.1, 1.9));
         character.initialGender = CharacterSex.female;

--- a/NightgamesMod/nightgames/characters/Jewel.java
+++ b/NightgamesMod/nightgames/characters/Jewel.java
@@ -14,6 +14,7 @@ import nightgames.combat.Result;
 import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
+import nightgames.start.NpcConfiguration;
 
 public class Jewel extends BasePersonality {
     /**
@@ -22,7 +23,14 @@ public class Jewel extends BasePersonality {
     private static final long serialVersionUID = 6677748046858370216L;
 
     public Jewel() {
-        super("Jewel", 1);
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public Jewel(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Jewel", 1, charConfig, commonConfig);
+    }
+
+    protected void applyBasicStats() {
         preferredCockMod = CockMod.enlightened;
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("tanktop"));
@@ -45,7 +53,7 @@ public class Jewel extends BasePersonality {
         character.body.add(PussyPart.normal);
         // fairly feminine face
         character.body.add(new FacePart(.1, 1.9));
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/Kat.java
+++ b/NightgamesMod/nightgames/characters/Kat.java
@@ -13,6 +13,7 @@ import nightgames.combat.Result;
 import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
+import nightgames.start.NpcConfiguration;
 import nightgames.status.Feral;
 import nightgames.status.Horny;
 import nightgames.status.Stsflag;
@@ -24,7 +25,14 @@ public class Kat extends BasePersonality {
     private static final long serialVersionUID = -8169646189131720872L;
 
     public Kat() {
-        super("Kat", 10);
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public Kat(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Kat", 10, charConfig, commonConfig);
+    }
+
+    protected void applyBasicStats() {
         preferredCockMod = CockMod.primal;
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("Tshirt"));
@@ -54,7 +62,7 @@ public class Kat extends BasePersonality {
         character.body.add(EarPart.cat);
         // mostly feminine face
         character.body.add(new FacePart(.1, 2.3));
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/Mara.java
+++ b/NightgamesMod/nightgames/characters/Mara.java
@@ -49,8 +49,6 @@ public class Mara extends BasePersonality {
         character.setTrophy(Item.MaraTrophy);
         character.plan = Plan.hunting;
         character.mood = Emotion.confident;
-        character.body.add(BreastsPart.b);
-        character.body.add(PussyPart.normal);
         character.body.add(new FacePart(.1, 1.1));
         character.initialGender = CharacterSex.female;
     }

--- a/NightgamesMod/nightgames/characters/Mara.java
+++ b/NightgamesMod/nightgames/characters/Mara.java
@@ -12,6 +12,7 @@ import nightgames.combat.Result;
 import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
+import nightgames.start.NpcConfiguration;
 import nightgames.status.Hypersensitive;
 import nightgames.status.Oiled;
 
@@ -22,7 +23,14 @@ public class Mara extends BasePersonality {
     private static final long serialVersionUID = -3812726803607189573L;
 
     public Mara() {
-        super("Mara", 1);
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public Mara(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Mara", 1, charConfig, commonConfig);
+    }
+
+    protected void applyBasicStats() {
         preferredCockMod = CockMod.bionic;
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("Tshirt"));
@@ -43,7 +51,7 @@ public class Mara extends BasePersonality {
         character.body.add(BreastsPart.b);
         character.body.add(PussyPart.normal);
         character.body.add(new FacePart(.1, 1.1));
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/Mara.java
+++ b/NightgamesMod/nightgames/characters/Mara.java
@@ -31,6 +31,7 @@ public class Mara extends BasePersonality {
     }
 
     protected void applyBasicStats() {
+        character.isStartCharacter = true;
         preferredCockMod = CockMod.bionic;
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("Tshirt"));

--- a/NightgamesMod/nightgames/characters/Maya.java
+++ b/NightgamesMod/nightgames/characters/Maya.java
@@ -80,7 +80,6 @@ public class Maya extends BasePersonality {
         character.plan = Plan.hunting;
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.d);
-        character.body.add(PussyPart.normal);
         character.initialGender = CharacterSex.female;
         preferredCockMod = CockMod.error;
     }

--- a/NightgamesMod/nightgames/characters/Maya.java
+++ b/NightgamesMod/nightgames/characters/Maya.java
@@ -9,15 +9,29 @@ import nightgames.global.Flag;
 import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
+import nightgames.start.NpcConfiguration;
 import nightgames.status.Drowsy;
 import nightgames.status.Energized;
+
+import java.util.Optional;
 
 public class Maya extends BasePersonality {
 
     private static final long serialVersionUID = 447375506153223682L;
 
-    public Maya(int playerLvl) {
-        super("Maya", 50);
+    public Maya(int playerLevel) {
+        this(playerLevel, Optional.empty(), Optional.empty());
+    }
+
+    public Maya(int playerLevel, Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Maya", 50, charConfig, commonConfig);
+
+        while (character.getLevel() < playerLevel + 20) {
+            character.ding();
+        }
+    }
+
+    protected void applyBasicStats() {
         character.outfitPlan.add(Clothing.getByID("camisole"));
         character.outfitPlan.add(Clothing.getByID("blouse"));
         character.outfitPlan.add(Clothing.getByID("lacepanties"));
@@ -62,14 +76,12 @@ public class Maya extends BasePersonality {
         character.add(Trait.cursed);
         Global.gainSkills(character);
         character.setTrophy(Item.MayaTrophy);
-        while (character.getLevel() < playerLvl + 20) {
-            character.ding();
-        }
+
         character.plan = Plan.hunting;
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.d);
         character.body.add(PussyPart.normal);
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
         preferredCockMod = CockMod.error;
     }
 

--- a/NightgamesMod/nightgames/characters/NPC.java
+++ b/NightgamesMod/nightgames/characters/NPC.java
@@ -59,6 +59,7 @@ public class NPC extends Character {
             emotes.put(e, 0);
         }
         mood = Emotion.confident;
+        initialGender = CharacterSex.female;
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/NPC.java
+++ b/NightgamesMod/nightgames/characters/NPC.java
@@ -49,6 +49,7 @@ public class NPC extends Character {
     public Emotion mood;
     public Plan plan;
     private boolean fakeHuman;
+    public boolean isStartCharacter = false;
 
     public NPC(String name, int level, Personality ai) {
         super(name, level);

--- a/NightgamesMod/nightgames/characters/Personality.java
+++ b/NightgamesMod/nightgames/characters/Personality.java
@@ -91,32 +91,6 @@ public interface Personality extends Serializable {
     public default void eot(Combat c, Character opponent, Skill last) {
         // noop
     }
-    
-    public static Personality getByType(String type) {
-        type = type.toLowerCase();
-        switch (type) {
-            case "angel":
-                return new Angel();
-            case "cassie":
-                return new Cassie();
-            case "eve":
-                return new Eve();
-            case "jewel":
-                return new Jewel();
-            case "kat":
-                return new Kat();
-            case "mara":
-                return new Mara();
-            case "maya":
-                return new Maya(1);
-            case "reyka":
-                return new Reyka();
-            case "airi":
-                return new Airi();
-            default:
-                throw new IllegalArgumentException("Unknown Personality: " + type);
-        }
-    }
 
     public void setCharacter(NPC npc);
 }

--- a/NightgamesMod/nightgames/characters/Player.java
+++ b/NightgamesMod/nightgames/characters/Player.java
@@ -1,11 +1,9 @@
 package nightgames.characters;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import nightgames.start.PlayerConfiguration;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -46,14 +44,41 @@ public class Player extends Character {
      *
      */
     public GUI gui;
-    public String sex;
     private Growth growth;
     public int traitPoints;
     private List<Addiction> addictions;
 
-    public Player(String name, CharacterSex sex) {
+    public Player(String name) {
+        this(name, CharacterSex.male, Optional.empty(), new HashMap<>());
+    }
+
+    // TODO(Ryplinn): This initialization pattern is very close to that of BasePersonality. I think it makes sense to make NPC the primary parent of characters instead of BasePersonality.
+    public Player(String name, CharacterSex sex, Optional<PlayerConfiguration> config,
+                    Map<Attribute, Integer> selectedAttributes) {
         super(name, 1);
-        if (sex == CharacterSex.female || sex == CharacterSex.herm) {
+        initialGender = sex;
+        applyBasicStats();
+        applyConfigStats(config);
+        finishCharacter(selectedAttributes);
+
+    }
+
+    private void applyBasicStats() {
+        willpower.setMax(willpower.max());
+        availableAttributePoints = 0;
+        setTrophy(Item.PlayerTrophy);
+        growth = new Growth();
+        setGrowth();
+        addictions = new ArrayList<>();
+    }
+
+    private void applyConfigStats(Optional<PlayerConfiguration> config) {
+        config.ifPresent(c -> c.apply(this));
+    }
+
+    private void finishCharacter(Map<Attribute, Integer> selectedAttributes) {
+        att.putAll(selectedAttributes);
+        if (initialGender == CharacterSex.female || initialGender == CharacterSex.herm) {
             outfitPlan.add(Clothing.getByID("bra"));
             outfitPlan.add(Clothing.getByID("panties"));
         } else {
@@ -63,19 +88,8 @@ public class Player extends Character {
         outfitPlan.add(Clothing.getByID("jeans"));
         outfitPlan.add(Clothing.getByID("socks"));
         outfitPlan.add(Clothing.getByID("sneakers"));
-
-        willpower.setMax(willpower.max());
         change();
-        availableAttributePoints = 0;
-        setTrophy(Item.PlayerTrophy);
-        body.finishBody(sex);
-        growth = new Growth();
-        setGrowth();
-        addictions = new ArrayList<>();
-    }
-
-    public Player(String name) {
-        this(name, CharacterSex.male);
+        body.finishBody(initialGender);
     }
 
     public void setGrowth() {

--- a/NightgamesMod/nightgames/characters/Reyka.java
+++ b/NightgamesMod/nightgames/characters/Reyka.java
@@ -14,12 +14,20 @@ import nightgames.combat.Result;
 import nightgames.global.Global;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
+import nightgames.start.NpcConfiguration;
 
 public class Reyka extends BasePersonality {
     private static final long serialVersionUID = 8553663088141308399L;
 
     public Reyka() {
-        super("Reyka", 10);
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public Reyka(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Reyka", 1, charConfig, commonConfig);
+    }
+
+    protected void applyBasicStats() {
         preferredCockMod = CockMod.incubus;
         character.outfitPlan.add(Clothing.getByID("tanktop"));
         character.outfitPlan.add(Clothing.getByID("miniskirt"));
@@ -51,7 +59,7 @@ public class Reyka extends BasePersonality {
         character.body.add(WingsPart.demonic);
         character.body.add(EarPart.pointed);
         character.body.add(new FacePart(4.5, 1.1));
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/Yui.java
+++ b/NightgamesMod/nightgames/characters/Yui.java
@@ -1,6 +1,7 @@
 package nightgames.characters;
 
 import java.util.HashSet;
+import java.util.Optional;
 
 import nightgames.actions.Action;
 import nightgames.actions.Movement;
@@ -10,10 +11,18 @@ import nightgames.combat.Combat;
 import nightgames.combat.Result;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
+import nightgames.start.NpcConfiguration;
 
 public class Yui extends BasePersonality {
     public Yui() {
-        super("Yui", 1);
+        this(Optional.empty(), Optional.empty());
+    }
+
+    public Yui(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("Yui", 1, charConfig, commonConfig);
+    }
+
+    protected void applyBasicStats() {
         character.outfitPlan.add(Clothing.getByID("bra"));
         character.outfitPlan.add(Clothing.getByID("Tshirt"));
         character.outfitPlan.add(Clothing.getByID("panties"));
@@ -24,7 +33,11 @@ public class Yui extends BasePersonality {
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.c);
         character.body.add(PussyPart.normal);
-        character.body.finishBody(CharacterSex.female);
+        character.initialGender = CharacterSex.female;
+    }
+
+    public void setGrowth() {
+        // TODO method stub
     }
 
     /**

--- a/NightgamesMod/nightgames/characters/Yui.java
+++ b/NightgamesMod/nightgames/characters/Yui.java
@@ -32,7 +32,6 @@ public class Yui extends BasePersonality {
         character.plan = Plan.hunting;
         character.mood = Emotion.confident;
         character.body.add(BreastsPart.c);
-        character.body.add(PussyPart.normal);
         character.initialGender = CharacterSex.female;
     }
 

--- a/NightgamesMod/nightgames/characters/body/BasicCockPart.java
+++ b/NightgamesMod/nightgames/characters/body/BasicCockPart.java
@@ -68,6 +68,10 @@ public enum BasicCockPart implements CockPart {
         return desc;
     }
 
+    public String getName() {
+        return name();
+    }
+
     @Override
     public double getHotness(Character self, Character opponent) {
         double hotness = Math.log(size / 4 + 1) / Math.log(2) - 1;

--- a/NightgamesMod/nightgames/characters/body/Body.java
+++ b/NightgamesMod/nightgames/characters/body/Body.java
@@ -273,13 +273,26 @@ public class Body implements Cloneable {
         return breasts;
     }
 
+    public CockPart getLargestCock() {
+        List<BodyPart> parts = get("cock");
+        if (parts.size() == 0) {
+            return null;
+        }
+        CockPart largest = BasicCockPart.tiny;
+        for (BodyPart part : parts) {
+            CockPart cock = (CockPart) part;
+            largest = cock.getSize() >= largest.getSize() ? cock : largest;
+        }
+        return largest;
+    }
+
     public CockPart getCockBelow(double size) {
         List<BodyPart> parts = get("cock");
         List<CockPart> upgradable = new ArrayList<CockPart>();
         for (BodyPart part : parts) {
-            CockPart b = (CockPart) part;
-            if (b.getSize() < size) {
-                upgradable.add(b);
+            CockPart cock = (CockPart) part;
+            if (cock.getSize() < size) {
+                upgradable.add(cock);
             }
         }
         if (upgradable.size() == 0) {
@@ -632,17 +645,26 @@ public class Body implements Cloneable {
                 if (!has("face")) {
                     add(new FacePart(0, 2));
                 }
+                if (get("breasts").size() == 0) {
+                    add(BreastsPart.b);
+                }
                 break;
             case male:
                 baseFemininity -= 2;
                 if (!has("face")) {
                     add(new FacePart(0, -2));
                 }
+                if (!has("balls")) {
+                    add(new GenericBodyPart("balls", 0, 1.0, 1.5, "balls", ""));
+                }
                 break;
             case herm:
                 baseFemininity += 1;
                 if (!has("face")) {
                     add(new FacePart(0, 0));
+                }
+                if (get("breasts").size() == 0) {
+                    add(BreastsPart.b);
                 }
                 break;
             case asexual:
@@ -652,29 +674,43 @@ public class Body implements Cloneable {
                 }
                 break;
         }
-        if (sex == CharacterSex.female || sex == CharacterSex.herm) {
-            if (get("pussy").size() == 0) {
-                add(PussyPart.normal);
-            }
-            if (get("breasts").size() == 0) {
-                add(BreastsPart.b);
+        for (BodyPart part : requiredParts) {
+            if (!has(part.getType())) {
+                add(part);
             }
         }
-        if (sex == CharacterSex.male || sex == CharacterSex.herm) {
-            if (get("cock").size() == 0) {
+    }
+
+    CharacterSex getEffectiveSex() {
+        boolean hasCock = has("cock");
+        boolean hasPussy = has("pussy");
+        if (hasCock && hasPussy) {
+            return CharacterSex.herm;
+        } else if (hasCock) {
+            return CharacterSex.male;
+        } else if (hasPussy) {
+            return CharacterSex.female;
+        } else {
+            return CharacterSex.asexual;
+        }
+    }
+
+    public void makeGenitalOrgans(CharacterSex sex) {
+        if (sex.hasPussy()) {
+            if (!has("pussy")) {
+                add(PussyPart.normal);
+            }
+
+        }
+        if (sex.hasCock()) {
+            if (!has("cock")) {
                 add(BasicCockPart.average);
             }
         }
         if (sex == CharacterSex.male) {
-            if (get("balls").size() == 0) {
-                add(new GenericBodyPart("balls", 0, 1.0, 1.5, "balls", ""));
-            }
+
         }
-        for (BodyPart part : requiredParts) {
-            if (get(part.getType()).size() == 0) {
-                add(part);
-            }
-        }
+
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/body/CockPart.java
+++ b/NightgamesMod/nightgames/characters/body/CockPart.java
@@ -7,6 +7,9 @@ public interface CockPart extends BodyPart {
 
     BodyPart applyMod(CockMod mod);
 
+    // Returns the result of Enum.name().
+    String getName();
+
     @Override
     public default double getFemininity(Character self) {
         return -3;

--- a/NightgamesMod/nightgames/characters/body/ModdedCockPart.java
+++ b/NightgamesMod/nightgames/characters/body/ModdedCockPart.java
@@ -192,6 +192,10 @@ public class ModdedCockPart implements CockPart {
         return getBase().getSize();
     }
 
+    public String getName() {
+        return getBase().getName();
+    }
+
     @Override
     public boolean isGeneric(Character self) {
         return false;

--- a/NightgamesMod/nightgames/characters/custom/CustomNPC.java
+++ b/NightgamesMod/nightgames/characters/custom/CustomNPC.java
@@ -32,6 +32,7 @@ public class CustomNPC extends BasePersonality {
     public CustomNPC(NPCData data, Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
         // Make the built-in character
         character = new NPC(data.getName(), data.getStats().level, this);
+        this.data = data;
         applyBasicStats();
         growth = new Growth();
         preferredCockMod = CockMod.error;
@@ -48,6 +49,7 @@ public class CustomNPC extends BasePersonality {
     protected void applyBasicStats() {
         preferredAttributes = new ArrayList<PreferredAttribute>(data.getPreferredAttributes());
 
+        character.isStartCharacter = data.isStartCharacter();
         character.outfitPlan.addAll(data.getTopOutfit());
         character.outfitPlan.addAll(data.getBottomOutfit());
         character.closet.addAll(character.outfitPlan);

--- a/NightgamesMod/nightgames/characters/custom/CustomNPC.java
+++ b/NightgamesMod/nightgames/characters/custom/CustomNPC.java
@@ -38,10 +38,11 @@ public class CustomNPC extends BasePersonality {
         preferredCockMod = CockMod.error;
         preferredAttributes = new ArrayList<PreferredAttribute>();
         setGrowth();
+        character.body.makeGenitalOrgans(character.initialGender);
 
         // Apply config changes
-        applyConfigStats(commonConfig);
-        applyConfigStats(charConfig);
+        Optional<NpcConfiguration> mergedConfig = NpcConfiguration.mergeOptionalNpcConfigs(charConfig, commonConfig);
+        mergedConfig.ifPresent(cfg -> cfg.apply(character));
 
         character.body.finishBody(character.initialGender);
     }

--- a/NightgamesMod/nightgames/characters/custom/CustomNPC.java
+++ b/NightgamesMod/nightgames/characters/custom/CustomNPC.java
@@ -3,18 +3,17 @@ package nightgames.characters.custom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import nightgames.characters.Attribute;
-import nightgames.characters.BasePersonality;
+import nightgames.characters.*;
 import nightgames.characters.Character;
-import nightgames.characters.Emotion;
-import nightgames.characters.Trait;
-import nightgames.characters.body.Body;
+import nightgames.characters.body.CockMod;
 import nightgames.combat.Combat;
 import nightgames.combat.Result;
 import nightgames.global.Global;
 import nightgames.items.ItemAmount;
+import nightgames.start.NpcConfiguration;
 
 public class CustomNPC extends BasePersonality {
     /**
@@ -23,10 +22,30 @@ public class CustomNPC extends BasePersonality {
     private NPCData data;
     private static final long serialVersionUID = -8169646189131720872L;
 
-    public CustomNPC(NPCData data) {
-        super(data.getName(), data.getStats().level);
-        this.data = data;
-        growth = data.getGrowth();
+    public static final String TYPE_PREFIX = "CUSTOM_";
+
+    public CustomNPC(NPCData data){
+        this(data, Optional.empty(), Optional.empty());
+    }
+
+    // TODO: Once built-in NPCs are data-driven, this should be able to be replaced with a call to super().
+    public CustomNPC(NPCData data, Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        // Make the built-in character
+        character = new NPC(data.getName(), data.getStats().level, this);
+        applyBasicStats();
+        growth = new Growth();
+        preferredCockMod = CockMod.error;
+        preferredAttributes = new ArrayList<PreferredAttribute>();
+        setGrowth();
+
+        // Apply config changes
+        applyConfigStats(commonConfig);
+        applyConfigStats(charConfig);
+
+        character.body.finishBody(character.initialGender);
+    }
+
+    protected void applyBasicStats() {
         preferredAttributes = new ArrayList<PreferredAttribute>(data.getPreferredAttributes());
 
         character.outfitPlan.addAll(data.getTopOutfit());
@@ -43,17 +62,24 @@ public class CustomNPC extends BasePersonality {
         character.plan = data.getPlan();
         character.mood = Emotion.confident;
         character.custom = true;
+
         try {
             character.body = data.getBody().clone(character);
         } catch (CloneNotSupportedException e) {
             e.printStackTrace();
-            character.body = new Body(character);
         }
-        character.body.finishBody(data.getSex());
+
+        character.initialGender = data.getSex();
+
         for (ItemAmount i : data.getStartingItems()) {
             character.gain(i.item, i.amount);
         }
+
         Global.gainSkills(character);
+    }
+
+    public void setGrowth() {
+        growth = data.getGrowth();
     }
 
     @Override
@@ -169,7 +195,7 @@ public class CustomNPC extends BasePersonality {
 
     @Override
     public String getType() {
-        return "CUSTOM_" + data.getType();
+        return TYPE_PREFIX + data.getType();
     }
 
     @Override

--- a/NightgamesMod/nightgames/characters/custom/DataBackedNPCData.java
+++ b/NightgamesMod/nightgames/characters/custom/DataBackedNPCData.java
@@ -39,6 +39,7 @@ public class DataBackedNPCData implements NPCData {
     Body body;
     AiModifiers aiModifiers;
     Map<CommentSituation, String> comments;
+    boolean isStartCharacter;
 
     public DataBackedNPCData() {
         preferredAttributes = new ArrayList<>();
@@ -59,6 +60,7 @@ public class DataBackedNPCData implements NPCData {
         recruitment = new RecruitmentData();
         aiModifiers = new AiModifiers();
         comments = new HashMap<>();
+        isStartCharacter = false;
     }
 
     @Override
@@ -181,5 +183,9 @@ public class DataBackedNPCData implements NPCData {
     @Override
     public Map<CommentSituation, String> getComments() {
         return comments;
+    }
+
+    public boolean isStartCharacter() {
+        return isStartCharacter;
     }
 }

--- a/NightgamesMod/nightgames/characters/custom/JSONSourceNPCDataLoader.java
+++ b/NightgamesMod/nightgames/characters/custom/JSONSourceNPCDataLoader.java
@@ -116,6 +116,10 @@ public class JSONSourceNPCDataLoader {
                 loadAiModifiers((JSONArray) object.get("ai-modifiers"), data.aiModifiers);
             }
 
+            if (object.containsKey("start")) {
+                data.isStartCharacter = JSONUtils.readBoolean(object, "start");
+            }
+
             if (object.containsKey("male-pref")) {
                 data.aiModifiers.setMalePref(Optional.of((double) JSONUtils.readFloat(object, "male-pref")));
             } else {

--- a/NightgamesMod/nightgames/characters/custom/NPCData.java
+++ b/NightgamesMod/nightgames/characters/custom/NPCData.java
@@ -56,4 +56,6 @@ public interface NPCData {
     AiModifiers getAiModifiers();
 
     Map<CommentSituation, String> getComments();
+
+    boolean isStartCharacter();
 }

--- a/NightgamesMod/nightgames/global/Global.java
+++ b/NightgamesMod/nightgames/global/Global.java
@@ -219,6 +219,8 @@ public class Global {
         Clothing.buildClothingTable();
         learnSkills(human);
         rebuildCharacterPool(config);
+        // Add starting characters to players
+        players.addAll(characterPool.values().stream().filter(npc -> npc.isStartCharacter).collect(Collectors.toList()));
         if (!cfgFlags.isEmpty()) {
             flags.clear();
             cfgFlags.stream().map(Flag::name).forEach(flags::add);

--- a/NightgamesMod/nightgames/global/Global.java
+++ b/NightgamesMod/nightgames/global/Global.java
@@ -1113,11 +1113,7 @@ public class Global {
             date = JSONUtils.readInteger(object, "date");
             String time = JSONUtils.readString(object, "time");
             dawn = time.equals("dawn");
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (org.json.simple.parser.ParseException e) {
+        } catch (IOException|org.json.simple.parser.ParseException e) {
             e.printStackTrace();
         }
         gui.populatePlayer(human);

--- a/NightgamesMod/nightgames/global/JSONUtils.java
+++ b/NightgamesMod/nightgames/global/JSONUtils.java
@@ -1,14 +1,21 @@
 package nightgames.global;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.json.simple.parser.ParseException;
 
 public class JSONUtils {
     public static int readInteger(JSONObject struct, String key) {
@@ -65,5 +72,22 @@ public class JSONUtils {
             }
         }
         return res;
+    }
+
+    public static JSONObject rootFromFile(Path path) {
+        JSONObject root;
+        try (Reader read = Files.newBufferedReader(path)) {
+            root = (JSONObject) JSONValue.parseWithException(read);
+        } catch (IOException|ParseException e) {
+            throw new RuntimeException("Error reading JSON file.");
+        }
+
+        return root;
+    }
+
+    public static <T> Optional<T> getIfExists(JSONObject obj, String key, Function<Object, T> f) {
+        if (!obj.containsKey(key))
+            return Optional.empty();
+        return Optional.ofNullable(f.apply(obj.get(key)));
     }
 }

--- a/NightgamesMod/nightgames/modifier/CustomModifierLoader.java
+++ b/NightgamesMod/nightgames/modifier/CustomModifierLoader.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -189,7 +190,7 @@ public final class CustomModifierLoader {
         Global.buildParser();
         Global.buildModifierPool();
         Global.buildActionPool();
-        Global.buildSkillPool(new Player("player", CharacterSex.male));
+        Global.buildSkillPool(new Player("player"));
         Modifier mod = readModifier(obj);
         System.out.println(mod);
     }

--- a/NightgamesMod/nightgames/modifier/skill/BanSkillsModifier.java
+++ b/NightgamesMod/nightgames/modifier/skill/BanSkillsModifier.java
@@ -40,8 +40,10 @@ public class BanSkillsModifier extends SkillModifier implements ModifierComponen
         } else if (obj.containsKey("skills")) {
             List<String> names = JSONUtils.loadStringsFromArr(obj, "skills");
             Skill[] skills = names.stream()
-                            .map(name -> Global.getSkillPool().stream().filter(s -> s.getName().equals(name)).findAny()
-                                            .orElseThrow(() -> new IllegalArgumentException("No such skill: " + name)))
+                            .map(name -> Global.getSkillPool().stream().filter(s -> s.getName().equals(name))
+                                            .findAny().<IllegalArgumentException>orElseThrow(
+                                                            () -> new IllegalArgumentException(
+                                                                            "No such skill: " + name)))
                             .toArray(Skill[]::new);
             return new BanSkillsModifier(skills);
         }

--- a/NightgamesMod/nightgames/skills/TemptressStripTease.java
+++ b/NightgamesMod/nightgames/skills/TemptressStripTease.java
@@ -58,7 +58,7 @@ public class TemptressStripTease extends StripTease {
     @Override
     public boolean resolve(Combat c, Character target) {
         int technique = getSelf().get(Attribute.Technique);
-        assert technique > 0;
+        //assert technique > 0;
 
         if (isDance(c)) {
             if (getSelf().human()) {

--- a/NightgamesMod/nightgames/start/BodyConfiguration.java
+++ b/NightgamesMod/nightgames/start/BodyConfiguration.java
@@ -11,55 +11,67 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static nightgames.start.ConfigurationUtils.mergeOptionals;
+
 class BodyConfiguration {
 
-    private Archetype type;
-    private Optional<GenitalConfiguration> genitals;
-    private Optional<BreastsPart> breasts;
-    private Optional<AssPart> ass;
-    private Optional<EarPart> ears;
-    private Optional<TailPart> tail;
-    private Optional<WingsPart> wings;
-    private List<TentaclePart> tentacles;
-    private double hotness;
+    protected Optional<Archetype> type;
+    protected Optional<GenitalConfiguration> genitals;
+    protected Optional<BreastsPart> breasts;
+    protected Optional<AssPart> ass;
+    protected Optional<EarPart> ears;
+    protected Optional<TailPart> tail;
+    protected Optional<WingsPart> wings;
+    protected Optional<List<TentaclePart>> tentacles;
+    protected Optional<Double> hotness;
 
     BodyConfiguration() {
-        type = Archetype.REGULAR;
+        type = Optional.empty();
         genitals = Optional.empty();
         breasts = Optional.empty();
         ass = Optional.empty();
         ears = Optional.empty();
         tail = Optional.empty();
         wings = Optional.empty();
-        tentacles = new ArrayList<>();
-        // TODO: This overwrites base character hotness if not specified in the StartConfiguration.
-        hotness = 1.0;
+        tentacles = Optional.empty();
+        hotness = Optional.empty();
+    }
+    
+    BodyConfiguration(BodyConfiguration primaryConfig, BodyConfiguration secondaryConfig) {
+        type = primaryConfig.type;
+        genitals = mergeOptionals(primaryConfig.genitals, secondaryConfig.genitals);
+        breasts = mergeOptionals(primaryConfig.breasts, secondaryConfig.breasts);
+        ass = mergeOptionals(primaryConfig.ass, secondaryConfig.ass);
+        ears = mergeOptionals(primaryConfig.ears, secondaryConfig.ears);
+        tail = mergeOptionals(primaryConfig.tail, secondaryConfig.tail);
+        wings = mergeOptionals(primaryConfig.wings, secondaryConfig.wings);
+        tentacles = mergeOptionals(primaryConfig.tentacles, secondaryConfig.tentacles);
+        hotness = mergeOptionals(primaryConfig.hotness, secondaryConfig.hotness);
     }
 
     static BodyConfiguration parse(JSONObject obj) {
-        BodyConfiguration cfg = new BodyConfiguration();
+        BodyConfiguration config = new BodyConfiguration();
         if (obj.containsKey("archetype"))
-            cfg.type = Archetype.valueOf(JSONUtils.readString(obj, "archetype")
-                                                  .toUpperCase());
+            config.type = Optional.of(Archetype.valueOf(JSONUtils.readString(obj, "archetype").toUpperCase()));
         if (obj.containsKey("breasts"))
-            cfg.breasts = Optional.of(BreastsPart.valueOf(JSONUtils.readString(obj, "breasts")
+            config.breasts = Optional.of(BreastsPart.valueOf(JSONUtils.readString(obj, "breasts")
                                                                    .toLowerCase()));
         if (obj.containsKey("ass"))
-            cfg.ass = Optional.of(JSONUtils.readString(obj, "ass")
+            config.ass = Optional.of(JSONUtils.readString(obj, "ass")
                                            .equals("basic") ? AssPart.generic : new AnalPussyPart());
 
         if (obj.containsKey("ears"))
-            cfg.ears = Optional.of(EarPart.valueOf(JSONUtils.readString(obj, "ears")
+            config.ears = Optional.of(EarPart.valueOf(JSONUtils.readString(obj, "ears")
                                                             .toLowerCase()));
         if (obj.containsKey("tail") && !obj.get("tail").equals("none"))
-            cfg.tail = Optional.of(TailPart.valueOf(JSONUtils.readString(obj, "tail")
+            config.tail = Optional.of(TailPart.valueOf(JSONUtils.readString(obj, "tail")
                                                              .toLowerCase()));
         if (obj.containsKey("wings") && !obj.get("wings").equals("none"))
-            cfg.wings = Optional.of(WingsPart.valueOf(JSONUtils.readString(obj, "wings")
+            config.wings = Optional.of(WingsPart.valueOf(JSONUtils.readString(obj, "wings")
                                                                .toLowerCase()));
 
         if (obj.containsKey("genitals"))
-            cfg.genitals = Optional.of(GenitalConfiguration.parse((JSONObject) obj.get("genitals")));
+            config.genitals = Optional.of(GenitalConfiguration.parse((JSONObject) obj.get("genitals")));
         
         List<TentaclePart> list = new ArrayList<>();
         if (obj.containsKey("tentacles")) {
@@ -68,9 +80,13 @@ class BodyConfiguration {
                 list.add(parseTentacle((JSONObject) o));
             }
         }
-        cfg.tentacles = list;
+        config.tentacles = Optional.of(list);
 
-        return cfg;
+        if (obj.containsKey("hotness")) {
+            config.hotness = Optional.of((double) JSONUtils.readFloat(obj, "hotness"));
+        }
+
+        return config;
     }
 
     private static TentaclePart parseTentacle(JSONObject o) {
@@ -84,19 +100,28 @@ class BodyConfiguration {
     }
 
     void apply(Body body) {
-/**/        genitals.ifPresent(gc -> gc.process(body));
+        type.ifPresent(t -> t.apply(body));
+/**/    genitals.ifPresent(gc -> gc.apply(body));
         replaceIfPresent(body, breasts);
         replaceIfPresent(body, ass);
         replaceIfPresent(body, ears);
         replaceIfPresent(body, tail);
         replaceIfPresent(body, wings);
-        tentacles.forEach(body::add);
-        body.hotness = hotness;
+        applyTentacles(body);
+        hotness.ifPresent(h -> body.hotness = h);
     }
-
+    
     private void replaceIfPresent(Body body, Optional<? extends BodyPart> part) {
         if (part.isPresent()) {
             body.addReplace(part.get(), 1);
+        }
+    }
+
+    private void applyTentacles(Body body) {
+        if (tentacles.isPresent()) {
+            body.removeAll("tentacles");
+            tentacles.get().forEach(body::add);
+
         }
     }
     
@@ -108,9 +133,7 @@ class BodyConfiguration {
         result = prime * result + ((breasts == null) ? 0 : breasts.hashCode());
         result = prime * result + ((ears == null) ? 0 : ears.hashCode());
         result = prime * result + ((genitals == null) ? 0 : genitals.hashCode());
-        long temp;
-        temp = Double.doubleToLongBits(hotness);
-        result = prime * result + (int) (temp ^ (temp >>> 32));
+        result = prime * result + ((hotness == null) ? 0 : hotness.hashCode());
         result = prime * result + ((tail == null) ? 0 : tail.hashCode());
         result = prime * result + ((tentacles == null) ? 0 : tentacles.hashCode());
         result = prime * result + ((type == null) ? 0 : type.hashCode());
@@ -148,7 +171,11 @@ class BodyConfiguration {
                 return false;
         } else if (!genitals.equals(other.genitals))
             return false;
-        if (Double.doubleToLongBits(hotness) != Double.doubleToLongBits(other.hotness))
+        if (hotness == null) {
+            if (other.hotness != null) {
+                return false;
+            }
+        } else if (!hotness.equals(other.hotness))
             return false;
         if (tail == null) {
             if (other.tail != null)
@@ -182,7 +209,7 @@ class BodyConfiguration {
         }
 
         public static GenitalConfiguration parse(JSONObject o) {
-            GenitalConfiguration cfg = new GenitalConfiguration();
+            GenitalConfiguration config = new GenitalConfiguration();
             if (o.containsKey("cock")) {
                 CockConfiguration cock = new CockConfiguration();
                 JSONObject co = (JSONObject) o.get("cock");
@@ -192,15 +219,15 @@ class BodyConfiguration {
                 if (co.containsKey("type") && !co.get("type").equals("basic")) {
                     cock.type = Optional.of(CockMod.valueOf(JSONUtils.readString(co, "type").toLowerCase()));
                 }
-                cfg.cock = Optional.of(cock);
+                config.cock = Optional.of(cock);
             }
             if (o.containsKey("pussy")) {
-                cfg.pussy = Optional.of(PussyPart.valueOf(JSONUtils.readString(o, "pussy").toLowerCase()));
+                config.pussy = Optional.of(PussyPart.valueOf(JSONUtils.readString(o, "pussy").toLowerCase()));
             }
-            return cfg;
+            return config;
         }
 
-        private void process(Body body) {
+        private void apply(Body body) {
             body.removeAll("cock");
             body.removeAll("pussy");
             if (cock.isPresent())
@@ -208,6 +235,7 @@ class BodyConfiguration {
                              .build());
             if (pussy.isPresent())
                 body.add(pussy.get());
+
         }
     }
 
@@ -237,14 +265,16 @@ class BodyConfiguration {
         private CockMod cockMod;
         private PussyPart pussy;
 
-        private Archetype(CockMod cockMod, PussyPart pussy) {
+        Archetype(CockMod cockMod, PussyPart pussy) {
             this.cockMod = cockMod;
             this.pussy = pussy;
         }
 
         private void apply(Body body) {
-            if (body.has("cock") && this != REGULAR)
-                body.addReplace(new ModdedCockPart(BasicCockPart.average, cockMod), 1);
+            if (body.has("cock") && this != REGULAR) {
+                BasicCockPart size = BasicCockPart.valueOf(body.getLargestCock().getName());
+                body.addReplace(new ModdedCockPart(size, cockMod), 1);
+            }
             if (body.has("pussy") && this != REGULAR)
                 body.addReplace(pussy, 1);
             switch (this) {
@@ -266,13 +296,15 @@ class BodyConfiguration {
         }
     }
 
+
+
     public static void main(String[] args) {
         String test = "{\"archetype\":\"regular\",\"genitals\":{\"cock\":{\"type\":\"bionic\",\"length\":\"huge"
                         + "\"}},\"breasts\":\"c\",\"ass\":\"AnalPussy\",\"ears\":\"pointed\",\"tail\":\"cat\",\"wings"
                         + "\":\"demonic\",\"tentacles\":[],\"hotness\":1.0}";
-        BodyConfiguration cfg = parse((JSONObject) JSONValue.parse(test));
+        BodyConfiguration config = parse((JSONObject) JSONValue.parse(test));
         Body body = new Body();
-        cfg.apply(body);
+        config.apply(body);
         body.finishBody(CharacterSex.male);
 
         System.out.println(body);

--- a/NightgamesMod/nightgames/start/CharacterConfiguration.java
+++ b/NightgamesMod/nightgames/start/CharacterConfiguration.java
@@ -15,14 +15,16 @@ import nightgames.characters.Trait;
 import nightgames.global.JSONUtils;
 import nightgames.items.clothing.Clothing;
 
+import static nightgames.start.ConfigurationUtils.mergeOptionals;
+
 public abstract class CharacterConfiguration {
 
     protected Optional<String> name;
     protected Optional<CharacterSex> gender;
     protected Map<Attribute, Integer> attributes;
-    protected OptionalInt money;
-    protected OptionalInt level;
-    protected OptionalInt xp;
+    protected Optional<Integer> money;
+    protected Optional<Integer> level;
+    protected Optional<Integer> xp;
     protected Optional<List<Trait>> traits;
     protected Optional<BodyConfiguration> body;
     protected Optional<List<String>> clothing;
@@ -31,12 +33,38 @@ public abstract class CharacterConfiguration {
         name = Optional.empty();
         gender = Optional.empty();
         attributes = new HashMap<>();
-        money = OptionalInt.empty();
-        level = OptionalInt.empty();
-        xp = OptionalInt.empty();
+        money = Optional.empty();
+        level = Optional.empty();
+        xp = Optional.empty();
         traits = Optional.empty();
         body = Optional.empty();
         clothing = Optional.empty();
+    }
+
+    /** Merges the fields of two CharacterConfigurations into the a new CharacterConfiguration.
+     * @param primaryConfig The primary configuration.
+     * @param secondaryConfig The secondary configuration. Field values will be overridden by values in primaryConfig.
+     * return
+     */
+    protected CharacterConfiguration(CharacterConfiguration primaryConfig, CharacterConfiguration secondaryConfig) {
+        this();
+        name = mergeOptionals(primaryConfig.name, secondaryConfig.name);
+        gender = mergeOptionals(primaryConfig.gender, secondaryConfig.gender);
+        attributes.putAll(secondaryConfig.attributes);
+        attributes.putAll(primaryConfig.attributes);
+        money = mergeOptionals(primaryConfig.money, secondaryConfig.money);
+        level = mergeOptionals(primaryConfig.level, secondaryConfig.level);
+        xp = mergeOptionals(primaryConfig.xp, secondaryConfig.xp);
+        clothing = mergeOptionals(primaryConfig.clothing, secondaryConfig.clothing);
+        if (primaryConfig.body.isPresent()) {
+            if (secondaryConfig.body.isPresent()) {
+                body = Optional.of(new BodyConfiguration(primaryConfig.body.get(), secondaryConfig.body.get()));
+            } else {
+                body = primaryConfig.body;
+            }
+        } else {
+            body = secondaryConfig.body;
+        }
     }
 
     protected final void apply(Character base) {
@@ -62,6 +90,9 @@ public abstract class CharacterConfiguration {
         return this.gender;
     }
 
+    /** Parses fields common to PlayerConfiguration and NpcConfigurations.
+     * @param obj The configuration read from the JSON config file.
+     */
     protected void parseCommon(JSONObject obj) {
         name = JSONUtils.getIfExists(obj, "name", Object::toString);
         gender = JSONUtils.getIfExists(obj, "gender", o -> CharacterSex.valueOf(o.toString()
@@ -70,11 +101,11 @@ public abstract class CharacterConfiguration {
         body = JSONUtils.getIfExists(obj, "body", o -> BodyConfiguration.parse((JSONObject) o));
         clothing = JSONUtils.getIfExists(obj, "clothing", o -> parseClothing((JSONArray) o));
         if (obj.containsKey("money"))
-            money = OptionalInt.of(JSONUtils.readInteger(obj, "money"));
+            money = Optional.of(JSONUtils.readInteger(obj, "money"));
         if (obj.containsKey("level"))
-            level = OptionalInt.of(JSONUtils.readInteger(obj, "level"));
+            level = Optional.of(JSONUtils.readInteger(obj, "level"));
         if (obj.containsKey("xp"))
-            xp = OptionalInt.of(JSONUtils.readInteger(obj, "xp"));
+            xp = Optional.of(JSONUtils.readInteger(obj, "xp"));
         if (obj.containsKey("attributes")) {
             JSONObject attrs = (JSONObject) obj.get("attributes");
             for (Object a : attrs.keySet()) {
@@ -82,7 +113,11 @@ public abstract class CharacterConfiguration {
                 attributes.put(att, JSONUtils.readInteger(attrs, att.name()));
             }
         }
+
     }
+
+
+
 
     private static List<Trait> parseTraits(JSONArray arr) {
         List<Trait> traits = new ArrayList<>();

--- a/NightgamesMod/nightgames/start/ConfigurationUtils.java
+++ b/NightgamesMod/nightgames/start/ConfigurationUtils.java
@@ -1,0 +1,16 @@
+package nightgames.start;
+
+import java.util.Optional;
+
+/**
+ * Created by Ryplinn on 6/14/2016.
+ */
+public class ConfigurationUtils {
+    protected static <T> Optional<T> mergeOptionals(Optional<T> primary, Optional<T> secondary) {
+        if (primary.isPresent()) {
+            return primary;
+        } else {
+            return secondary;
+        }
+    }
+}

--- a/NightgamesMod/nightgames/start/NpcConfiguration.java
+++ b/NightgamesMod/nightgames/start/NpcConfiguration.java
@@ -1,45 +1,30 @@
 package nightgames.start;
 
-import java.util.Map;
-import java.util.Optional;
-
+import nightgames.global.JSONUtils;
 import org.json.simple.JSONObject;
 
 import nightgames.characters.NPC;
-import nightgames.characters.Personality;
 
-class NpcConfiguration extends CharacterConfiguration {
+import java.util.Optional;
 
-    private Optional<String> type;
+public class NpcConfiguration extends CharacterConfiguration {
 
-    private NpcConfiguration() {
-        type = Optional.empty();
-    }
+    // Optional because NpcConfiguration is used for both NPCs and adjustments common to all NPCs
+    protected String type;
 
-    NPC build(Optional<NpcConfiguration> common) {
-        if (!type.isPresent() && common.isPresent()) {
-            throw new IllegalStateException("No type for npc");
-        } else if (!common.isPresent()) {
-            throw new UnsupportedOperationException("Tried to build NPC from all_npcs configuration");
+    public final void apply(NPC base) {
+        super.apply(base);
+        if (gender.isPresent()) {
+            base.initialGender = gender.get();
         }
-        Personality pers = Personality.getByType(type.get());
-        NPC npc;
-        pers.setCharacter(npc = new NPC(name.orElse(type.get()), level, pers));
-        if (common.isPresent()) {
-           common.get().processCommon(npc);
-        }
-        processCommon(npc);
-        return npc;
     }
 
     public static NpcConfiguration parse(JSONObject obj) {
         NpcConfiguration cfg = new NpcConfiguration();
         cfg.parseCommon(obj);
-        cfg.type = getIfExists(obj, "type", Object::toString);
-        /*if (!cfg.type.isPresent()) {
-            throw new RuntimeException("Error: Tried to specify an NPC without a type! (" + cfg.name.orElse("no name") + ")");
-        }*/
+        cfg.type = JSONUtils.getIfExists(obj, "type", Object::toString)
+                        .orElseThrow(() -> new RuntimeException("Tried parsing NPC without a type."));
+
         return cfg;
     }
-
 }

--- a/NightgamesMod/nightgames/start/NpcConfiguration.java
+++ b/NightgamesMod/nightgames/start/NpcConfiguration.java
@@ -1,5 +1,8 @@
 package nightgames.start;
 
+import com.sun.javafx.scene.control.behavior.OptionalBoolean;
+import nightgames.characters.CharacterSex;
+import nightgames.characters.body.Body;
 import nightgames.global.JSONUtils;
 import org.json.simple.JSONObject;
 
@@ -7,29 +10,80 @@ import nightgames.characters.NPC;
 
 import java.util.Optional;
 
+import static nightgames.start.ConfigurationUtils.mergeOptionals;
+
 public class NpcConfiguration extends CharacterConfiguration {
 
     // Optional because NpcConfiguration is used for both NPCs and adjustments common to all NPCs
     protected String type;
     public Optional<Boolean> isStartCharacter;
 
-    public final void apply(NPC base) {
-        super.apply(base);
-        if (gender.isPresent()) {
-            base.initialGender = gender.get();
+    public NpcConfiguration() {
+        isStartCharacter = Optional.empty();
+    }
+
+    /** Makes a new NpcConfiguration from merging two others.
+     * @param primaryConfig Will override field values from secondaryConfig.
+     * @param secondaryConfig Field values will be overridden by primaryConfig.
+     */
+    public NpcConfiguration(NpcConfiguration primaryConfig, NpcConfiguration secondaryConfig) {
+        super(primaryConfig, secondaryConfig);
+        isStartCharacter = mergeOptionals(primaryConfig.isStartCharacter, secondaryConfig.isStartCharacter);
+        type = primaryConfig.type;
+    }
+
+    public static Optional<NpcConfiguration> mergeOptionalNpcConfigs(Optional<NpcConfiguration> primaryConfig,
+                    Optional<NpcConfiguration> secondaryConfig) {
+        if (primaryConfig.isPresent()) {
+            if (secondaryConfig.isPresent()) {
+                return Optional.of(new NpcConfiguration(primaryConfig.get(), secondaryConfig.get()));
+            } else {
+                return primaryConfig;
+            }
+        } else {
+            return secondaryConfig;
         }
+    }
+
+    public final void apply(NPC base) {
+        if (gender.isPresent()) {
+            CharacterSex sex = gender.get();
+            base.initialGender = sex;
+            // If gender is present in config, make genitals conform to it. This will be overridden if config also supplies genitals.
+            if (!sex.hasCock()) {
+                base.body.removeAll("cock");
+            }
+            if (!sex.hasPussy()) {
+                base.body.removeAll("pussy");
+            }
+            base.body.makeGenitalOrgans(sex);
+        }
+        super.apply(base);
         if (isStartCharacter.isPresent()) {
             base.isStartCharacter = isStartCharacter.get();
         }
     }
 
-    public static NpcConfiguration parse(JSONObject obj) {
-        NpcConfiguration cfg = new NpcConfiguration();
-        cfg.parseCommon(obj);
-        cfg.type = JSONUtils.getIfExists(obj, "type", Object::toString)
-                        .orElseThrow(() -> new RuntimeException("Tried parsing NPC without a type."));
-        cfg.isStartCharacter = JSONUtils.getIfExists(obj, "start", b -> (boolean) b);
+    /** Parse fields from the all_npcs section.
+     * @param obj The configuration from the JSON config file.
+     * @return A new NpcConfiguration as specified in the config file.
+     */
+    public static NpcConfiguration parseAllNpcs(JSONObject obj) {
+        NpcConfiguration config = new NpcConfiguration();
+        config.isStartCharacter = JSONUtils.getIfExists(obj, "start", b -> (boolean) b);
+        config.parseCommon(obj);
+        return config;
+    }
 
-        return cfg;
+    /** Parse a character-specific NPC config.
+     * @param obj The configuration from the JSON config file.
+     * @return A new NpcConfiguration as specified in the config file.
+     */
+    public static NpcConfiguration parse(JSONObject obj) {
+        NpcConfiguration config = NpcConfiguration.parseAllNpcs(obj);
+        config.type = JSONUtils.getIfExists(obj, "type", Object::toString)
+                        .orElseThrow(() -> new RuntimeException("Tried parsing NPC without a type."));
+
+        return config;
     }
 }

--- a/NightgamesMod/nightgames/start/NpcConfiguration.java
+++ b/NightgamesMod/nightgames/start/NpcConfiguration.java
@@ -11,11 +11,15 @@ public class NpcConfiguration extends CharacterConfiguration {
 
     // Optional because NpcConfiguration is used for both NPCs and adjustments common to all NPCs
     protected String type;
+    public Optional<Boolean> isStartCharacter;
 
     public final void apply(NPC base) {
         super.apply(base);
         if (gender.isPresent()) {
             base.initialGender = gender.get();
+        }
+        if (isStartCharacter.isPresent()) {
+            base.isStartCharacter = isStartCharacter.get();
         }
     }
 
@@ -24,6 +28,7 @@ public class NpcConfiguration extends CharacterConfiguration {
         cfg.parseCommon(obj);
         cfg.type = JSONUtils.getIfExists(obj, "type", Object::toString)
                         .orElseThrow(() -> new RuntimeException("Tried parsing NPC without a type."));
+        cfg.isStartCharacter = JSONUtils.getIfExists(obj, "start", b -> (boolean) b);
 
         return cfg;
     }

--- a/NightgamesMod/nightgames/start/PlayerConfiguration.java
+++ b/NightgamesMod/nightgames/start/PlayerConfiguration.java
@@ -1,22 +1,15 @@
 package nightgames.start;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
+import nightgames.characters.Player;
+import nightgames.global.JSONUtils;
 import org.json.simple.JSONObject;
 
-import nightgames.characters.CharacterSex;
-import nightgames.characters.Player;
-import nightgames.characters.Trait;
-
-class PlayerConfiguration extends CharacterConfiguration {
+public class PlayerConfiguration extends CharacterConfiguration {
 
     private boolean allowsMoreTraits;
     private int attributePoints;
     
-    private PlayerConfiguration() {}
+    public PlayerConfiguration() {}
 
     boolean allowsMoreTraits() {
         return allowsMoreTraits;
@@ -26,31 +19,15 @@ class PlayerConfiguration extends CharacterConfiguration {
         return attributePoints;
     }
 
-    Player build(String name, Optional<CharacterSex> gender, Optional<List<Trait>> traits) {
-        Player p = new Player(name, gender.orElse(CharacterSex.male));
-        if (!gender.isPresent()) {
-            if (gender.isPresent()) {
-                super.gender = gender;
-            } else {
-                super.gender = Optional.of(CharacterSex.male);
-            }
-        }
-        if (allowsMoreTraits && traits.isPresent()) {
-            List<Trait> extraTraits = traits.get();
-            if (super.traits.isPresent())
-                super.traits.get().addAll(extraTraits);
-            else
-                super.traits = Optional.of(extraTraits);
-        }
-        processCommon(p);
-        return p;
+    public void apply(Player player) {
+        super.apply(player);
     }
 
     public static PlayerConfiguration parse(JSONObject obj) {
         PlayerConfiguration cfg = new PlayerConfiguration();
         cfg.parseCommon(obj);
-        cfg.allowsMoreTraits = getIfExists(obj, "trait_choice", o -> (boolean) o).orElse(true);
-        cfg.attributePoints = getIfExists(obj, "attribute_points", o -> ((Long) o).intValue()).orElse(11);
+        cfg.allowsMoreTraits = JSONUtils.getIfExists(obj, "trait_choice", o -> (boolean) o).orElse(true);
+        cfg.attributePoints = JSONUtils.getIfExists(obj, "attribute_points", o -> ((Long) o).intValue()).orElse(11);
         return cfg;
     }
 

--- a/NightgamesMod/nightgames/start/StartConfiguration.java
+++ b/NightgamesMod/nightgames/start/StartConfiguration.java
@@ -2,7 +2,6 @@ package nightgames.start;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -33,27 +32,13 @@ public class StartConfiguration {
 
     private String name, summary;
     private boolean enabled;
-    private PlayerConfiguration player;
+    public PlayerConfiguration player;
     private List<NpcConfiguration> npcs;
-    private NpcConfiguration npcCommon;
+    public NpcConfiguration npcCommon;
     private List<Flag> flags;
 
     private StartConfiguration() {
 
-    }
-
-    public Player buildPlayer(String name) {
-        return buildPlayer(name, null, null);
-    }
-
-    public Player buildPlayer(String name, List<Trait> traits, CharacterSex gender) {
-        return player.build(name, Optional.ofNullable(gender), Optional.ofNullable(traits));
-    }
-
-    public List<NPC> buildNpcs() {
-        return npcs.stream()
-                   .map(n -> n.build(Optional.ofNullable(npcCommon)))
-                   .collect(Collectors.toList());
     }
 
     public String getName() {
@@ -83,6 +68,19 @@ public class StartConfiguration {
     public int availableAttributePoints() {
         return player.getAttributePoints();
     }
+
+    /**
+     * Sets the configured basic attributes to the specified values. Useful for applying spent attribute points after creation.
+     *
+     * @param power Value to apply to the player's Power attribute.
+     * @param seduction Value to apply to the player's Seduction attribute.
+     * @param cunning Value to apply to the player's Cunning attribute.
+     */
+    public void setPlayerAttributePoints(int power, int seduction, int cunning) {
+        player.attributes.put(Attribute.Power, power);
+        player.attributes.put(Attribute.Seduction, seduction);
+        player.attributes.put(Attribute.Cunning, cunning);
+    }
     
     public Map<Attribute, Integer> playerAttributes() {
         return new HashMap<>(player.attributes);
@@ -98,20 +96,15 @@ public class StartConfiguration {
     }
 
     @SuppressWarnings("unchecked")
-    public static StartConfiguration parse(Reader read) throws ParseException {
+    public static StartConfiguration parse(JSONObject root) throws ParseException {
         StartConfiguration cfg = new StartConfiguration();
-        JSONObject root;
-        try {
-            root = (JSONObject) JSONValue.parseWithException(read);
-        } catch (IOException e) {
-            throw new RuntimeException("Error reading file.");
-        }
 
         cfg.name = JSONUtils.readString(root, "name");
         cfg.summary = JSONUtils.readString(root, "summary");
         cfg.enabled = JSONUtils.readBoolean(root, "enabled");
         cfg.player = PlayerConfiguration.parse((JSONObject) root.get("player"));
-        cfg.npcCommon = NpcConfiguration.parse((JSONObject) root.get("all_npcs"));
+        cfg.npcCommon = new NpcConfiguration();
+        cfg.npcCommon.parseCommon((JSONObject) root.get("all_npcs"));
 
         JSONArray npcs = (JSONArray) root.get("npcs");
         cfg.npcs = ((Stream<Object>) npcs.stream()).map(o -> (JSONObject) o)
@@ -124,6 +117,10 @@ public class StartConfiguration {
         return cfg;
     }
 
+    public Optional<NpcConfiguration> findNpcConfig(String type) {
+        return npcs.stream().filter(npc -> type.equals(npc.type)).findAny();
+    }
+
     public static Collection<StartConfiguration> loadConfigurations() {
         Path dir = new File("starts/").toPath();
         Collection<StartConfiguration> res = new ArrayList<>();
@@ -132,7 +129,7 @@ public class StartConfiguration {
                 if (file.toString()
                         .endsWith(".json")) {
                     try {
-                        res.add(parse(Files.newBufferedReader(file)));
+                        res.add(parse(JSONUtils.rootFromFile(file)));
                     } catch (Exception e) {
                         System.out.println("Failed to load configuration from " + file.toString() + ": ");
                         System.out.flush();
@@ -149,9 +146,8 @@ public class StartConfiguration {
 
     public static void main(String[] args) throws IOException, ParseException {
         Clothing.buildClothingTable();
-        Reader reader = Files.newBufferedReader(new File("starts/Male Start.json").toPath());
-        StartConfiguration cfg = parse(reader);
-        reader.close();
+        Path path = new File("starts/Male Start.json").toPath();
+        StartConfiguration cfg = parse(JSONUtils.rootFromFile(path));
         System.out.println(cfg);
     }
 }

--- a/NightgamesMod/nightgames/start/StartConfiguration.java
+++ b/NightgamesMod/nightgames/start/StartConfiguration.java
@@ -69,19 +69,6 @@ public class StartConfiguration {
         return player.getAttributePoints();
     }
 
-    /**
-     * Sets the configured basic attributes to the specified values. Useful for applying spent attribute points after creation.
-     *
-     * @param power Value to apply to the player's Power attribute.
-     * @param seduction Value to apply to the player's Seduction attribute.
-     * @param cunning Value to apply to the player's Cunning attribute.
-     */
-    public void setPlayerAttributePoints(int power, int seduction, int cunning) {
-        player.attributes.put(Attribute.Power, power);
-        player.attributes.put(Attribute.Seduction, seduction);
-        player.attributes.put(Attribute.Cunning, cunning);
-    }
-    
     public Map<Attribute, Integer> playerAttributes() {
         return new HashMap<>(player.attributes);
     }
@@ -103,8 +90,7 @@ public class StartConfiguration {
         cfg.summary = JSONUtils.readString(root, "summary");
         cfg.enabled = JSONUtils.readBoolean(root, "enabled");
         cfg.player = PlayerConfiguration.parse((JSONObject) root.get("player"));
-        cfg.npcCommon = new NpcConfiguration();
-        cfg.npcCommon.parseCommon((JSONObject) root.get("all_npcs"));
+        cfg.npcCommon = NpcConfiguration.parseAllNpcs((JSONObject) root.get("all_npcs"));
 
         JSONArray npcs = (JSONArray) root.get("npcs");
         cfg.npcs = ((Stream<Object>) npcs.stream()).map(o -> (JSONObject) o)

--- a/NightgamesTests/nightgames/characters/TestAngel.java
+++ b/NightgamesTests/nightgames/characters/TestAngel.java
@@ -1,31 +1,91 @@
 package nightgames.characters;
 
-import java.util.Optional;
-
-import nightgames.characters.body.BreastsPart;
-import nightgames.characters.body.CockMod;
-import nightgames.characters.body.FacePart;
-import nightgames.characters.body.PussyPart;
-import nightgames.characters.body.WingsPart;
+import nightgames.Resources.ResourceLoader;
+import nightgames.characters.*;
+import nightgames.characters.Character;
+import nightgames.characters.body.*;
+import nightgames.characters.custom.CustomNPC;
+import nightgames.characters.custom.JSONSourceNPCDataLoader;
 import nightgames.combat.Combat;
 import nightgames.combat.Result;
 import nightgames.global.Global;
+import nightgames.global.JSONUtils;
 import nightgames.items.Item;
 import nightgames.items.clothing.Clothing;
 import nightgames.start.NpcConfiguration;
 
-public class Angel extends BasePersonality {
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class TestAngel extends BasePersonality {
     /**
      *
      */
     private static final long serialVersionUID = -8169646189131720872L;
 
-    public Angel() {
+    public static final NPC baseTestAngelChar = makeBaseAngel();
+
+    /**
+     * A version of the TestAngel Character with all fields explicitly specified as their intended initial values.
+     * @return basic TestAngel.
+     */
+    private static NPC makeBaseAngel() {
+        NPC baseChar = new NPC("TestAngel", 1, null);
+        baseChar.name = "TestAngel";
+        baseChar.level = 1;
+
+        baseChar.att.put(Attribute.Power, 5);
+        baseChar.att.put(Attribute.Seduction, 7);
+        baseChar.att.put(Attribute.Cunning, 5);
+        baseChar.att.put(Attribute.Perception, 6);
+        baseChar.att.put(Attribute.Speed, 5);
+
+        baseChar.money = 0;
+        baseChar.xp = 0;
+
+        baseChar.traits.clear();
+        baseChar.traits.add(Trait.undisciplined);
+        baseChar.traits.add(Trait.lickable);
+
+        baseChar.plan = Plan.hunting;
+        baseChar.mood = Emotion.confident;
+        baseChar.trophy = Item.AngelTrophy;
+
+        baseChar.body = new Body(baseChar, 1);
+        baseChar.body.add(BreastsPart.dd);
+        baseChar.body.add(new FacePart(.1, 4.2));
+        baseChar.body.add(PussyPart.normal);
+        baseChar.body.add(MouthPart.generic);
+        baseChar.body.add(new GenericBodyPart("hands", 0, 1, 1, "hands", ""));
+        baseChar.body.add(new GenericBodyPart("feet", 0, 1, 1, "feet", ""));
+        baseChar.body.add(new GenericBodyPart("skin", 0, 1, 1, "skin", ""));
+        baseChar.body.add(AssPart.generic);
+        baseChar.body.add(EarPart.normal);
+        baseChar.body.baseFemininity = 2;
+
+        baseChar.outfitPlan.add(Clothing.getByID("Tshirt"));
+        baseChar.outfitPlan.add(Clothing.getByID("bra"));
+        baseChar.outfitPlan.add(Clothing.getByID("thong"));
+        baseChar.outfitPlan.add(Clothing.getByID("miniskirt"));
+        baseChar.outfitPlan.add(Clothing.getByID("sandals"));
+        baseChar.change();
+
+        Global.gainSkills(baseChar);
+
+        return baseChar;
+    }
+
+    public TestAngel() {
         this(Optional.empty(), Optional.empty());
     }
 
-    public Angel(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
-        super("Angel", 1, charConfig, commonConfig);
+    public TestAngel(Optional<NpcConfiguration> charConfig, Optional<NpcConfiguration> commonConfig) {
+        super("TestAngel", 1, charConfig, commonConfig);
     }
 
     protected void applyBasicStats() {
@@ -36,8 +96,8 @@ public class Angel extends BasePersonality {
         character.outfitPlan.add(Clothing.getByID("miniskirt"));
         character.outfitPlan.add(Clothing.getByID("sandals"));
         character.change();
-        character.mod(Attribute.Seduction, 2);
-        character.mod(Attribute.Perception, 1);
+        character.att.put(Attribute.Seduction, 7);
+        character.att.put(Attribute.Perception, 6);
         Global.gainSkills(character);
 
         character.add(Trait.undisciplined);
@@ -52,8 +112,7 @@ public class Angel extends BasePersonality {
         character.initialGender = CharacterSex.female;
     }
 
-    @Override
-    public void setGrowth() {
+    @Override public void setGrowth() {
         growth.stamina = 1;
         growth.arousal = 5;
         growth.mojo = 1;
@@ -85,8 +144,7 @@ public class Angel extends BasePersonality {
         preferredAttributes.add(c -> Optional.of(Attribute.Seduction));
     }
 
-    @Override
-    public void rest(int time) {
+    @Override public void rest(int time) {
         if (character.rank >= 1) {
             if (!character.has(Trait.demigoddess) && character.money >= 1000) {
                 advance();
@@ -169,97 +227,95 @@ public class Angel extends BasePersonality {
         }
     }
 
-    @Override
-    public String bbLiner(Combat c) {
+    @Override public String bbLiner(Combat c) {
         return "Angel seems to enjoy your anguish in a way that makes you more than a little nervous. <i>\"That's a great look for you, I'd like to see it more often.\"</i>";
     }
 
-    @Override
-    public String nakedLiner(Combat c) {
+    @Override public String nakedLiner(Combat c) {
         return "Angel gives you a haughty look, practically showing off her body. <i>\"I can't blame you for wanting to see me naked, everyone does.\"</i>";
     }
 
-    @Override
-    public String stunLiner(Combat c) {
+    @Override public String stunLiner(Combat c) {
         return "Angel groans on the floor. <i>\"You really are a beast. It takes a gentle touch to please a lady.\"</i>";
     }
 
-    @Override
-    public String taunt(Combat c) {
+    @Override public String taunt(Combat c) {
         return "Angel pushes the head of your dick with her finger and watches it spring back into place. <i>\"You obviously can't help yourself. If only you were a little bigger, we could have a lot of fun.\"</i>";
     }
 
-    @Override
-    public String temptLiner(Combat c) {
+    @Override public String temptLiner(Combat c) {
         return "Angel looks at you with a grin, <i>\"You're almost drooling. Is staring at my body that much fun? If you want me that much, why don't you just sit there and let me make you feel good.\"</i>";
     }
 
-    @Override
-    public String victory(Combat c, Result flag) {
+    @Override public String victory(Combat c, Result flag) {
         character.arousal.empty();
         Character opponent = character.equals(c.p1) ? c.p2 : c.p1;
         String message = "";
         if (c.getStance().anallyPenetrated(opponent)) {
-            message = "Angel leans over you as she grinds her hips against yours. <i>\"You're going to come for me, aren't you?\"</i> she purrs into your ear. You shake your head; "
-                            + "no way could you live it down if you came while you had something in your ass. Angel frowns and gives your ass a firm slap. <i>\"No reach around for you "
-                            + "then,\"</i> she snaps. <i>\"We'll just do this the old fashion way.\"</i> She renews her assault on your poor ass and you feel your will slipping. Another solid slap "
-                            + "to ass sends you into a shuddering orgasm. Angel's triumphant laughter rings in your head as the shame makes you flush bright read.<p>Pulling her "
-                            + (character.hasDick() ? character.body.getRandomCock().describe(character) : "strapon")
-                            + " from your ass with a wet slurp Angel flips you over"
-                            + (!character.hasDick() ? " and removes the strapon." : ". ")
-                            + "She then squats down and lines your cock up with her now soaked pussy, <i>\"Do "
-                            + "a good enough good job and I might not tell my friends how you came like a whore while I fucked your ass.\"</i> She gloats with a smug grin on her face. "
-                            + "Appalled at the idea that she might share that information with anyone, you strengthen your resolve to fuck the woman above you.<p>Several minutes later, "
-                            + "you are breathing hard. Angel sits not far from you, face flush with pleasure. You smile internally as you sit, trying to catch your breath. No way "
-                            + "she could have been disappointed with that performance.  You can only gape as you look up to see Angel is gone along with your clothes. You sigh as you "
-                            + "stand and ready yourself to move on. You wouldn't put past Angel to tell her girlfriends regardless of how well you performed, you just hope that's as "
-                            + "far as that information goes.";
+            message =
+                            "Angel leans over you as she grinds her hips against yours. <i>\"You're going to come for me, aren't you?\"</i> she purrs into your ear. You shake your head; "
+                                            + "no way could you live it down if you came while you had something in your ass. Angel frowns and gives your ass a firm slap. <i>\"No reach around for you "
+                                            + "then,\"</i> she snaps. <i>\"We'll just do this the old fashion way.\"</i> She renews her assault on your poor ass and you feel your will slipping. Another solid slap "
+                                            + "to ass sends you into a shuddering orgasm. Angel's triumphant laughter rings in your head as the shame makes you flush bright read.<p>Pulling her "
+                                            + (character.hasDick() ?
+                                            character.body.getRandomCock().describe(character) :
+                                            "strapon") + " from your ass with a wet slurp Angel flips you over"
+                                            + (!character.hasDick() ? " and removes the strapon." : ". ")
+                                            + "She then squats down and lines your cock up with her now soaked pussy, <i>\"Do "
+                                            + "a good enough good job and I might not tell my friends how you came like a whore while I fucked your ass.\"</i> She gloats with a smug grin on her face. "
+                                            + "Appalled at the idea that she might share that information with anyone, you strengthen your resolve to fuck the woman above you.<p>Several minutes later, "
+                                            + "you are breathing hard. Angel sits not far from you, face flush with pleasure. You smile internally as you sit, trying to catch your breath. No way "
+                                            + "she could have been disappointed with that performance.  You can only gape as you look up to see Angel is gone along with your clothes. You sigh as you "
+                                            + "stand and ready yourself to move on. You wouldn't put past Angel to tell her girlfriends regardless of how well you performed, you just hope that's as "
+                                            + "far as that information goes.";
         } else if (c.getStance().inserted(character)) {
-            message = "Angel stares at you in the eye, while expertly thrusting in and out of your slobbering pussy. Your needy cunt quivers as she leans close and gives you a long steamy kiss, "
-                            + "tongue and all. You try to get away from her, but she holds you down and merciless pounds away at your overused pussy. You can tell she is turned on as well, but "
-                            + "it'll do you no good, as you're already feeling yourself slip over the edge. "
-                            + "<br><br>Finally it becomes too much, and you cum hard. You wrap your arms and legs unconsciously cling to Angel's body and you seek out "
-                            + "a needy kiss from her. Angel takes note of your convulsing body, and smirks, <i>\"I think you need some more training. I could make "
-                            + "anyone cum instantly while they're in me.\"</i> After a small pausing, Angel grins devilishly and resumes pumping in and out of pussy "
-                            + "in long leisurely strokes. <i>\"Hmm\" in fact, why don't I practice with you a bit? You know what they say, practice makes perfect!\" "
-                            + "You groan in frustration as your oversensitive cunt receives her cocks again. "
-                            + "<br><br>This could be a long night.";
+            message =
+                            "Angel stares at you in the eye, while expertly thrusting in and out of your slobbering pussy. Your needy cunt quivers as she leans close and gives you a long steamy kiss, "
+                                            + "tongue and all. You try to get away from her, but she holds you down and merciless pounds away at your overused pussy. You can tell she is turned on as well, but "
+                                            + "it'll do you no good, as you're already feeling yourself slip over the edge. "
+                                            + "<br><br>Finally it becomes too much, and you cum hard. You wrap your arms and legs unconsciously cling to Angel's body and you seek out "
+                                            + "a needy kiss from her. Angel takes note of your convulsing body, and smirks, <i>\"I think you need some more training. I could make "
+                                            + "anyone cum instantly while they're in me.\"</i> After a small pausing, Angel grins devilishly and resumes pumping in and out of pussy "
+                                            + "in long leisurely strokes. <i>\"Hmm\" in fact, why don't I practice with you a bit? You know what they say, practice makes perfect!\" "
+                                            + "You groan in frustration as your oversensitive cunt receives her cocks again. "
+                                            + "<br><br>This could be a long night.";
         } else if (c.getStance().inserted(opponent)) {
-            message = "Angel rides your cock passionately, pushing you inevitably closer to ejaculation. Her hot pussy is wrapped around your shaft like... well, exactly "
-                            + "what it is. More importantly, she's a master with her hip movements and you've held out against her as long as you can. You can only hope her own orgasm is equally "
-                            + "imminent. <i>\"Not even close,\"</i> She practically growls. <i>\"Don't give up now.\"</i> That's an impossible command. How can she expect you not to cum when "
-                            + "her slick love canal is milking your dick so expertly. As the last of your restraint crumbles, you let out a groan and shoot a thick load of semen "
-                            + "into her depths. <p>You lie on the floor panting as Angel looks down at you, somehow annoyed despite her victory. <i>\"Is that the best you can do? "
-                            + "You know it's rude to finish before your lover.\"</i> She starts to lick and suck on her finger, sensually. <i>\"Don't think you can get off on your own and the "
-                            + "sex is done just like that. I never let a man go until I'm satisfied.\"</i> You're quite willing to try to satisfy her in a variety of ways, but more "
-                            + "fucking is a physical impossibility at this point. Your spent penis has completely wilted by now, and it'll be a little while before there's any possibility "
-                            + "of it recovering. Angel gives you a pitiless smile and reaches behind her. <i>\"Don't worry. I know a good trick.\"</i><p>Whoa! You jerk in surprise as you feel "
-                            + "her spit-coated finger probing at your anus. <i>\"Don't complain,\"</i> She says, sliding the digit into your ass. <i>\"It's your own fault for being such a quick "
-                            + "shot.\"</i> As she moves her finger around, it creates an indescrible sensation. You dick starts to react immediately and returns to full mast faster than you "
-                            + "ever would have imagined. Angel wastes no time impaling herself on the you newly recovered member and rides you with renewed vigor. Fortunately she removes "
-                            + "the invading finger from your anus so you can focus on the pleasure of being back in her wonderful pussy. <p>She grinds against you, clearly turned on and "
-                            + "enjoying being filled again. She moans passionately and her vaginal walls rub and squeeze your cock. You move your hips to match Angel's movements and "
-                            + "her voice jumps in pitch. She's obviously enjoying your efforts much more this time, but she's so good too. You've just recently cum, but she's riding "
-                            + "through your endurance at an alarming rate. If you end up cumming again before she finishes, you're going to get the finger treatment again or worse. "
-                            + "Fortunately, you don't have to worry about that. Angel throws back her head and practically screams out her orgasm. Her love canal squeezes tightly, milking "
-                            + "out your second ejaculation. <p>Angel quickly recovers, standing up as a double load of cum leaks out between her thighs. <i>\"That'll do... for now.\"</i>";
+            message =
+                            "Angel rides your cock passionately, pushing you inevitably closer to ejaculation. Her hot pussy is wrapped around your shaft like... well, exactly "
+                                            + "what it is. More importantly, she's a master with her hip movements and you've held out against her as long as you can. You can only hope her own orgasm is equally "
+                                            + "imminent. <i>\"Not even close,\"</i> She practically growls. <i>\"Don't give up now.\"</i> That's an impossible command. How can she expect you not to cum when "
+                                            + "her slick love canal is milking your dick so expertly. As the last of your restraint crumbles, you let out a groan and shoot a thick load of semen "
+                                            + "into her depths. <p>You lie on the floor panting as Angel looks down at you, somehow annoyed despite her victory. <i>\"Is that the best you can do? "
+                                            + "You know it's rude to finish before your lover.\"</i> She starts to lick and suck on her finger, sensually. <i>\"Don't think you can get off on your own and the "
+                                            + "sex is done just like that. I never let a man go until I'm satisfied.\"</i> You're quite willing to try to satisfy her in a variety of ways, but more "
+                                            + "fucking is a physical impossibility at this point. Your spent penis has completely wilted by now, and it'll be a little while before there's any possibility "
+                                            + "of it recovering. Angel gives you a pitiless smile and reaches behind her. <i>\"Don't worry. I know a good trick.\"</i><p>Whoa! You jerk in surprise as you feel "
+                                            + "her spit-coated finger probing at your anus. <i>\"Don't complain,\"</i> She says, sliding the digit into your ass. <i>\"It's your own fault for being such a quick "
+                                            + "shot.\"</i> As she moves her finger around, it creates an indescrible sensation. You dick starts to react immediately and returns to full mast faster than you "
+                                            + "ever would have imagined. Angel wastes no time impaling herself on the you newly recovered member and rides you with renewed vigor. Fortunately she removes "
+                                            + "the invading finger from your anus so you can focus on the pleasure of being back in her wonderful pussy. <p>She grinds against you, clearly turned on and "
+                                            + "enjoying being filled again. She moans passionately and her vaginal walls rub and squeeze your cock. You move your hips to match Angel's movements and "
+                                            + "her voice jumps in pitch. She's obviously enjoying your efforts much more this time, but she's so good too. You've just recently cum, but she's riding "
+                                            + "through your endurance at an alarming rate. If you end up cumming again before she finishes, you're going to get the finger treatment again or worse. "
+                                            + "Fortunately, you don't have to worry about that. Angel throws back her head and practically screams out her orgasm. Her love canal squeezes tightly, milking "
+                                            + "out your second ejaculation. <p>Angel quickly recovers, standing up as a double load of cum leaks out between her thighs. <i>\"That'll do... for now.\"</i>";
         } else {
-            message = "It's too much. You can't focus on the fight with the wonderful sensations Angel is giving you. She smiles triumphantly and mercilessly teases your "
-                            + "twitching dick. Your orgasm is imminent, but you concentrate on holding it back as long as you can, determined not to give up until the end. Angel's "
-                            + "expression gradually changes to one of impatience. <i>\"Just cum already!\"</i> She slaps your dick and the shock breaks your concentration. Your pent-up "
-                            + "ejaculation bursts forth and covers her hands. <p>Without giving you a chance to recover, Angel pushes you on your back and positions her soaking "
-                            + "pussy over your face. <i>\"Show me you're good for more than cumming on command.\"</i> She grinds against your mouth as you eat her out. She reaches behind her "
-                            + "and roughly grabs your balls, encouraging you to focus more on pleasing her. Soon her writhing grows more passionate and her moans express her building "
-                            + "pleasure. She rewards your efforts by moving her hand to your dick, which is already starting to harden again. She jerks you off, using your previous climax "
-                            + "for lubricant. The growing volume of Angel's cries reveal that she's close to the end, so you focus on licking and sucking her clit, quickly bringing her to "
-                            + "a loud climax. Your own peak isn't far behind and soon you shoot another jet of cum into the air.\n\nAngel licks her semen covered hands clean and walks away "
-                            + "with your clothes, having seemingly forgotten about you.";
+            message =
+                            "It's too much. You can't focus on the fight with the wonderful sensations Angel is giving you. She smiles triumphantly and mercilessly teases your "
+                                            + "twitching dick. Your orgasm is imminent, but you concentrate on holding it back as long as you can, determined not to give up until the end. Angel's "
+                                            + "expression gradually changes to one of impatience. <i>\"Just cum already!\"</i> She slaps your dick and the shock breaks your concentration. Your pent-up "
+                                            + "ejaculation bursts forth and covers her hands. <p>Without giving you a chance to recover, Angel pushes you on your back and positions her soaking "
+                                            + "pussy over your face. <i>\"Show me you're good for more than cumming on command.\"</i> She grinds against your mouth as you eat her out. She reaches behind her "
+                                            + "and roughly grabs your balls, encouraging you to focus more on pleasing her. Soon her writhing grows more passionate and her moans express her building "
+                                            + "pleasure. She rewards your efforts by moving her hand to your dick, which is already starting to harden again. She jerks you off, using your previous climax "
+                                            + "for lubricant. The growing volume of Angel's cries reveal that she's close to the end, so you focus on licking and sucking her clit, quickly bringing her to "
+                                            + "a loud climax. Your own peak isn't far behind and soon you shoot another jet of cum into the air.\n\nAngel licks her semen covered hands clean and walks away "
+                                            + "with your clothes, having seemingly forgotten about you.";
         }
         return message;
     }
 
-    @Override
-    public String defeat(Combat c, Result flag) {
+    @Override public String defeat(Combat c, Result flag) {
         Character opponent = c.getOther(character);
         if (c.getStance().vaginallyPenetrated(character)) {
             return "You thrust your cock continously into Angel's dripping pussy. Her hot insides feel amazing, but you're sure you have enough of an advantage to risk "
@@ -276,7 +332,8 @@ public class Angel extends BasePersonality {
                             + "I had a continuous orgasm for at least two minutes and that's way more exhausting. It's been a long time since anyone's made me do that.\"</i> Wait, what? You'd "
                             + "never have guessed that she came if she hadn't said anything. <i>\"Just because you managed to beat me this time doesn't mean you can suddenly start acting "
                             + "lazy. If you let your guard down, I'm going to turn you into my own personal toy.\"</i> At that, she walks away naked.";
-        } if (opponent.hasDick()) {
+        }
+        if (opponent.hasDick()) {
             return "Angel trembles and moans as you guide her closer and closer to orgasm. You pump two fingers in and out of her pussy and lick her sensitive nether lips. "
                             + "Her swollen clit peeks out from under its hood and you pinch it gently between your teeth. Angel instantly screams in pleasure and arches her back. A "
                             + "flood of feminine juice sprays you as she loses control of her body.<p>It takes her a little while to catch her breath. She quickly pushes you on your "
@@ -295,8 +352,7 @@ public class Angel extends BasePersonality {
         }
     }
 
-    @Override
-    public String describe(Combat c) {
+    @Override public String describe(Combat c) {
         if (character.has(Trait.demigoddess)) {
             return "Angel's transformation seems to have taken inspiration from her own name. She has large angelic wings behind her, which combined with her long blonde hair and perfect unblemished "
                             + "skin gives her a positively divine appearance. Her appearance should be emanating holy purity, but instead her eyes and expression seems lewder than ever. "
@@ -309,8 +365,7 @@ public class Angel extends BasePersonality {
         }
     }
 
-    @Override
-    public String draw(Combat c, Result flag) {
+    @Override public String draw(Combat c, Result flag) {
         if (flag == Result.intercourse) {
             return "Angel pins you on your back, riding you with passion. You're close to the edge, but she's too far gone to take advantage of it. She's fucking you "
                             + "for her own pleasure rather than trying to win. Just as you feel your climax hit, Angel cries out in ecstasy and her pussy tightens to milk your "
@@ -338,18 +393,15 @@ public class Angel extends BasePersonality {
                         + "worry if you can't keep up. As long as you keep making me cum, I'll let you be my pet.\"</i>";
     }
 
-    @Override
-    public boolean fightFlight(Character opponent) {
+    @Override public boolean fightFlight(Character opponent) {
         return !character.mostlyNude() || opponent.mostlyNude();
     }
 
-    @Override
-    public boolean attack(Character opponent) {
+    @Override public boolean attack(Character opponent) {
         return true;
     }
 
-    @Override
-    public String victory3p(Combat c, Character target, Character assist) {
+    @Override public String victory3p(Combat c, Character target, Character assist) {
         if (target.human()) {
             return "Angel looks over your helpless body like a predator ready to feast. She kneels between your legs and teasingly licks your erection. She circles her "
                             + "tongue around the head, coating your penis thoroughly with saliva. When she's satisfied that it is sufficiently lubricated and twitching with need, "
@@ -359,8 +411,7 @@ public class Angel extends BasePersonality {
                             + "while she tries to catch as much of your seed in her mouth as she can.";
         }
         if (target.hasDick()) {
-            return String.format(
-                            "You present %s's naked, helpless form to Angel's tender "
+            return String.format("You present %s's naked, helpless form to Angel's tender "
                                             + "minstrations. Angel licks her lips and begins licking and stroking %s's"
                                             + " body. She's hitting all the right spots, because soon %s is squirming "
                                             + "and moaning in pleasure, and Angel hasn't even touched %s cock yet."
@@ -370,15 +421,14 @@ public class Angel extends BasePersonality {
                                             + "%s immediately jumps as if %s's been shocked. Soon it takes all of your"
                                             + " energy to control %s who is violently shaking in the throes of orgasm."
                                             + " You ease %s to the floor as %s goes completely limp, while Angel licks"
-                                            + " the cum from her fingers.",
-                            target.name(), target.name(), target.name(), target.possessivePronoun(), target.name(),
-                            target.name(), target.pronoun(), target.name(), target.directObject(), target.pronoun());
+                                            + " the cum from her fingers.", target.name(), target.name(), target.name(),
+                            target.possessivePronoun(), target.name(), target.name(), target.pronoun(), target.name(),
+                            target.directObject(), target.pronoun());
         }
         return "You present " + target.name()
                         + "'s naked, helpless form to Angel's tender minstrations. Angel licks her lips and begins licking and stroking "
-                        + target.name() + "'s body. She's " + "hitting all the right spots, because soon "
-                        + target.name()
-                        + " is squirming and moaning in pleasure, and Angel hasn't even touched her pussy yet. "
+                        + target.name() + "'s body. She's " + "hitting all the right spots, because soon " + target
+                        .name() + " is squirming and moaning in pleasure, and Angel hasn't even touched her pussy yet. "
                         + "Angel meets your eyes to focus your attention and slowly moves her fingers down the front of "
                         + target.name() + "'s body. You can't see her hands from "
                         + "this position, but you know when she reaches her target, because " + target.name()
@@ -389,8 +439,7 @@ public class Angel extends BasePersonality {
 
     }
 
-    @Override
-    public String intervene3p(Combat c, Character target, Character assist) {
+    @Override public String intervene3p(Combat c, Character target, Character assist) {
         if (target.human()) {
             return "You manage to overwhelm " + assist.name()
                             + " and bring her to the floor. You're able to grab both her arms and pin her helplessly beneath you. "
@@ -410,18 +459,15 @@ public class Angel extends BasePersonality {
         }
     }
 
-    @Override
-    public String startBattle(Character other) {
+    @Override public String startBattle(Character other) {
         return "Angel licks her lips and stalks you like a predator.";
     }
 
-    @Override
-    public boolean fit() {
+    @Override public boolean fit() {
         return !character.mostlyNude() && character.getStamina().percent() >= 50;
     }
 
-    @Override
-    public String night() {
+    @Override public String night() {
         return "As you start to head back after the match, Angel grabs your hand and drags you in the other direction. <i>\"You're officially kidnapped, because I haven't had "
                         + "enough sex yet tonight.\"</i> That makes sense... kinda? You did just finish three hours of intense sex-fighting. If she wants too much more than that, you're "
                         + "both going to end up pretty sleep deprived. Angel looks like she's struggling to put her thoughts into words. <i>\"I had enough sex in general, but I want some "
@@ -445,8 +491,7 @@ public class Angel extends BasePersonality {
         character.mod(Attribute.Divinity, 1);
     }
 
-    @Override
-    public boolean checkMood(Combat c, Emotion mood, int value) {
+    @Override public boolean checkMood(Combat c, Emotion mood, int value) {
         switch (mood) {
             case horny:
                 return value >= 50;
@@ -457,13 +502,11 @@ public class Angel extends BasePersonality {
         }
     }
 
-    @Override
-    public String orgasmLiner(Combat c) {
+    @Override public String orgasmLiner(Combat c) {
         return "<i>\"Mmm maybe you do have promise. Care to try that again?\"</i>";
     }
 
-    @Override
-    public String makeOrgasmLiner(Combat c) {
+    @Override public String makeOrgasmLiner(Combat c) {
         return "Angel stares you in the eye as your consciousness return from the precipice <i>\"Once isn't enough. I need more. You can do that for me right?\"</i>";
     }
 }

--- a/NightgamesTests/nightgames/start/NpcConfigurationTest.java
+++ b/NightgamesTests/nightgames/start/NpcConfigurationTest.java
@@ -1,6 +1,7 @@
 package nightgames.start;
 
 import nightgames.characters.Attribute;
+import nightgames.characters.CharacterSex;
 import nightgames.characters.NPC;
 import nightgames.characters.body.BreastsPart;
 import nightgames.global.JSONUtils;
@@ -17,6 +18,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -24,7 +27,8 @@ import java.util.Optional;
  * Created by Ryplinn on 6/11/2016.
  */
 public class NpcConfigurationTest {
-    StartConfiguration startCfg;
+    StartConfiguration startConfig;
+    NpcConfiguration angelConfig;
 
     @BeforeClass
     public static void setUpNpcConfigurationTest() {
@@ -32,21 +36,44 @@ public class NpcConfigurationTest {
     }
 
     @Before public void setUp() throws Exception {
+        Path file = new File("NightgamesTests/nightgames/start/TestStartConfig.json").toPath();
+        startConfig = StartConfiguration.parse(JSONUtils.rootFromFile(file));
+        angelConfig = startConfig.findNpcConfig("TestAngel")
+                        .orElseThrow(() -> new NoSuchElementException("TestAngel not found in test config."));
+    }
 
+    @Test public  void testConfigMerge() throws Exception {
+        NpcConfiguration mergedConfig = new NpcConfiguration(angelConfig, startConfig.npcCommon);
+        assertEquals("TestAngel", mergedConfig.type);
+        assertEquals(Optional.empty(), mergedConfig.gender);
+        Map<Attribute, Integer> expectedAttributes = new HashMap<>();
+        expectedAttributes.put(Attribute.Power, 13);
+        expectedAttributes.put(Attribute.Seduction, 20);
+        expectedAttributes.put(Attribute.Cunning, 15);
+        expectedAttributes.put(Attribute.Divinity, 10);
+        expectedAttributes.put(Attribute.Arcane, 2);
+        assertEquals(expectedAttributes, mergedConfig.attributes);
+        assertEquals(BodyConfiguration.Archetype.ANGEL, mergedConfig.body.get().type.get());
+        assertEquals(50, mergedConfig.xp.get().intValue());
     }
 
     @Test public void testBodyMerge() throws Exception {
-        Path file = new File("NightgamesTests/nightgames/start/TestStartConfig.json").toPath();
-        startCfg = StartConfiguration.parse(JSONUtils.rootFromFile(file));
-        NpcConfiguration angelCfg = startCfg.findNpcConfig("TestAngel")
-                        .orElseThrow(() -> new NoSuchElementException("TestAngel not found in test config."));
-
-        TestAngel angel = new TestAngel(Optional.of(angelCfg), Optional.of(startCfg.npcCommon));
+        TestAngel angel = new TestAngel(Optional.of(angelConfig), Optional.of(startConfig.npcCommon));
 
         // Starting stats should match config but breasts should be the same as base Angel if not overwritten in config.
-        assertEquals(angelCfg.attributes.get(Attribute.Seduction).intValue(),
+        assertEquals(angelConfig.attributes.get(Attribute.Seduction).intValue(),
                         angel.getCharacter().get(Attribute.Seduction));
         assertEquals(TestAngel.baseTestAngelChar.body.getLargestBreasts(), angel.getCharacter().body.getLargestBreasts());
+    }
+    
+    @Test public void testGenderChange() throws Exception {
+        angelConfig.gender = Optional.of(CharacterSex.male);
+        TestAngel angel = new TestAngel(Optional.of(angelConfig), Optional.of(startConfig.npcCommon));
+
+        assertFalse(angel.character.body.has("pussy"));
+        assertTrue(angel.character.body.has("cock"));
+        // Changing gender should not change (e.g.) breast size.
+        assertEquals(TestAngel.baseTestAngelChar.body.getLargestBreasts(), angel.character.body.getLargestBreasts());
     }
 
 }

--- a/NightgamesTests/nightgames/start/NpcConfigurationTest.java
+++ b/NightgamesTests/nightgames/start/NpcConfigurationTest.java
@@ -1,0 +1,52 @@
+package nightgames.start;
+
+import nightgames.characters.Attribute;
+import nightgames.characters.NPC;
+import nightgames.characters.body.BreastsPart;
+import nightgames.global.JSONUtils;
+import nightgames.items.clothing.Clothing;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import nightgames.characters.TestAngel;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * Created by Ryplinn on 6/11/2016.
+ */
+public class NpcConfigurationTest {
+    StartConfiguration startCfg;
+
+    @BeforeClass
+    public static void setUpNpcConfigurationTest() {
+        Clothing.buildClothingTable();
+    }
+
+    @Before public void setUp() throws Exception {
+
+    }
+
+    @Test public void testBodyMerge() throws Exception {
+        Path file = new File("NightgamesTests/nightgames/start/TestStartConfig.json").toPath();
+        startCfg = StartConfiguration.parse(JSONUtils.rootFromFile(file));
+        NpcConfiguration angelCfg = startCfg.findNpcConfig("TestAngel")
+                        .orElseThrow(() -> new NoSuchElementException("TestAngel not found in test config."));
+
+        TestAngel angel = new TestAngel(Optional.of(angelCfg), Optional.of(startCfg.npcCommon));
+
+        // Starting stats should match config but breasts should be the same as base Angel if not overwritten in config.
+        assertEquals(angelCfg.attributes.get(Attribute.Seduction).intValue(),
+                        angel.getCharacter().get(Attribute.Seduction));
+        assertEquals(TestAngel.baseTestAngelChar.body.getLargestBreasts(), angel.getCharacter().body.getLargestBreasts());
+    }
+
+}

--- a/NightgamesTests/nightgames/start/testStartConfig.json
+++ b/NightgamesTests/nightgames/start/testStartConfig.json
@@ -1,0 +1,51 @@
+{
+	"name":"Test Game Config",
+	"summary":"Start with all characters unlocked, and with the standard characters with their advanced classes. To compensate, the player gets higher starting attributes and a selection of beneficial traits.",
+	"enabled":true,
+	"player": {
+		"attributes": {
+			"Power":5,
+			"Seduction":5,
+			"Cunning":5
+		},
+		"attribute_points": 20,
+		"money": 15000,
+		"traits": [
+			"pussyhandler",
+			"dickhandler",
+			"limbTraining1",
+			"tongueTraining1",
+			"powerfulhips"
+		]
+	},
+	"npcs": [
+		{
+			"type":"TestAngel",
+			"attributes": {
+				"Power": 13,
+				"Seduction": 20,
+				"Cunning": 13,
+				"Divinity": 1
+			},
+			"body": {
+				"archetype":"ANGEL"
+			},
+			"traits": [
+				"demigoddess",
+				"divinity",
+				"proheels",
+				"undisciplined",
+				"lickable"
+			],
+			"clothing": [
+				"translucentshawl",
+				"bikinitop",
+				"bikinibottoms",
+				"highheels"
+			]
+		}
+
+	],
+	"all_npcs":{},
+	"flags":[]
+}

--- a/NightgamesTests/nightgames/start/testStartConfig.json
+++ b/NightgamesTests/nightgames/start/testStartConfig.json
@@ -24,8 +24,8 @@
 			"attributes": {
 				"Power": 13,
 				"Seduction": 20,
-				"Cunning": 13,
-				"Divinity": 1
+				"Cunning": 15,
+				"Divinity": 10
 			},
 			"body": {
 				"archetype":"ANGEL"
@@ -46,6 +46,15 @@
 		}
 
 	],
-	"all_npcs":{},
+	"all_npcs":{
+		"attributes": {
+			"Cunning": 14,
+			"Arcane": 2
+		},
+		"body": {
+			"archetype": "WITCH"
+		},
+		"xp": 50
+	},
 	"flags":[]
 }

--- a/NightgamesTests/nightgames/tests/CombatStats.java
+++ b/NightgamesTests/nightgames/tests/CombatStats.java
@@ -3,24 +3,13 @@ package nightgames.tests;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import nightgames.areas.Area;
-import nightgames.characters.Attribute;
-import nightgames.characters.BasePersonality;
+import nightgames.characters.*;
 import nightgames.characters.Character;
-import nightgames.characters.Eve;
-import nightgames.characters.Kat;
-import nightgames.characters.NPC;
-import nightgames.characters.Personality;
-import nightgames.characters.Player;
-import nightgames.characters.Reyka;
 import nightgames.combat.Combat;
 import nightgames.daytime.Daytime;
 import nightgames.global.DebugFlags;
@@ -120,7 +109,7 @@ public class CombatStats {
 
     public static void main(String[] args) {
         new Global(true);
-        Global.newGame(new Player("Dummy"));
+        Global.newGame("Dummy");
         Setup s1 = new Setup(1);
         // new CombatStats(s1).test();
 

--- a/NightgamesTests/nightgames/tests/SkillsTest.java
+++ b/NightgamesTests/nightgames/tests/SkillsTest.java
@@ -59,7 +59,7 @@ public class SkillsTest {
 	@Before
 	public void prepare() throws ParseException, IOException {
 		new Global(true);
-		Global.newGame(new Player("Dummy"));
+		Global.newGame("Dummy");
 		npcs1 = new ArrayList<Personality>();
 		npcs2 = new ArrayList<Personality>();
 		try {

--- a/NightgamesTests/nightgames/tests/SkillsTest.java
+++ b/NightgamesTests/nightgames/tests/SkillsTest.java
@@ -126,6 +126,7 @@ public class SkillsTest {
 		}
 	}
 
+	// TODO: May need to clone npc1 and npc2 here too, depending on how skills affect characters.
 	public void testCombo(Character npc1, Character npc2, Position pos) throws CloneNotSupportedException {
 		pos.top = npc1;
 		pos.bottom = npc2;
@@ -142,9 +143,9 @@ public class SkillsTest {
 					NPC npc1 = npcs1.get(i).getCharacter();
 					NPC npc2 = npcs2.get(j).getCharacter();
 					System.out.println("Testing [" + i + "]: " + npc1.getName() + " with [" + j + "]: " + npc2.getName() + " in Stance " + pos.getClass().getSimpleName());
-					testCombo(npc1, npc2, pos);
+					testCombo(npc1.clone(), npc2.clone(), pos);
 					System.out.println("Testing [" + j + "]: " + npc2.getName() + " with [" + i + "]: " + npc1.getName() + " in Stance " + pos.getClass().getSimpleName());
-					testCombo(npc1, npc2, pos);
+					testCombo(npc2.clone(), npc1.clone(), pos);
 				}
 			}
 		}

--- a/data/DefaultComments.json
+++ b/data/DefaultComments.json
@@ -246,10 +246,10 @@
 			},{
 				"situation": "SIXTYNINE_DOM_WIN",
 				"comment":"Come on {other:name}! Try a little harder down there!"
-			},
+			}
 		]
 	},{
-		"characters":"Reyka"
+		"characters":"Reyka",
 		"comments": [
 		{
 				"situation": "VAG_DOM_CATCH_WIN",
@@ -290,7 +290,7 @@
 			}
 		]
 	},{
-		"characters":"Airi"
+		"characters":"Airi",
 		"comments": [
 		{
 				"situation": "VAG_DOM_CATCH_WIN",

--- a/starts/AngelsVsDemons.json
+++ b/starts/AngelsVsDemons.json
@@ -21,6 +21,7 @@
 	"npcs": [
 		{
 			"type":"Angel",
+			"start":true,
 			"attributes": {
 				"Power": 10,
 				"Seduction": 15,
@@ -46,6 +47,7 @@
 		},
 		{
 			"type":"Cassie",
+			"start":true,
 			"attributes": {
 				"Power": 10,
 				"Seduction": 10,
@@ -74,6 +76,7 @@
 		},
 		{
 			"type":"Eve",
+			"start":true,
 			"attributes": {
 				"Power": 10,
 				"Seduction": 13,
@@ -111,6 +114,7 @@
 		},
 		{
 			"type":"Jewel",
+			"start":true,
 			"attributes": {
 				"Power": 15,
 				"Seduction": 10,
@@ -138,6 +142,7 @@
 		},
 		{
 			"type":"Mara",
+			"start":true,
 			"attributes": {
 				"Power": 10,
 				"Seduction": 10,
@@ -168,6 +173,7 @@
 		},
 		{
 			"type":"Reyka",
+			"start":true,
 			"attributes": {
 				"Power": 5,
 				"Seduction": 14,

--- a/starts/AngelsVsDemons.json
+++ b/starts/AngelsVsDemons.json
@@ -8,7 +8,7 @@
 			"Seduction":5,
 			"Cunning":5
 		},
-		"attribute_points": 20
+		"attribute_points": 20,
 		"money": 15000,
 		"traits": [
 			"pussyhandler",
@@ -20,7 +20,7 @@
 	},
 	"npcs": [
 		{
-			"type":"Angel"
+			"type":"Angel",
 			"attributes": {
 				"Power": 10,
 				"Seduction": 15,
@@ -45,7 +45,7 @@
 			]
 		},
 		{
-			"type":"Cassie"
+			"type":"Cassie",
 			"attributes": {
 				"Power": 10,
 				"Seduction": 10,
@@ -73,7 +73,7 @@
 			]
 		},
 		{
-			"type":"Eve"
+			"type":"Eve",
 			"attributes": {
 				"Power": 10,
 				"Seduction": 13,
@@ -84,7 +84,7 @@
 			},
 			"body": {
 				"gender":"herm",
-				"archetype":"DEMON"
+				"archetype":"DEMON",
 				"genitals": {
 					"cock": {
 						"length":"big"
@@ -92,7 +92,7 @@
 					"pussy":"normal"
 				},
 				"breasts":"d"
-			}
+			},
 			"traits": [
 				"succubus",
 				"exhibitionist",
@@ -110,7 +110,7 @@
 			]
 		},
 		{
-			"type":"Jewel"
+			"type":"Jewel",
 			"attributes": {
 				"Power": 15,
 				"Seduction": 10,
@@ -137,7 +137,7 @@
 			]
 		},
 		{
-			"type":"Mara"
+			"type":"Mara",
 			"attributes": {
 				"Power": 10,
 				"Seduction": 10,
@@ -167,12 +167,12 @@
 			]
 		},
 		{
-			"type":"Reyka"
+			"type":"Reyka",
 			"attributes": {
 				"Power": 5,
 				"Seduction": 14,
 				"Cunning": 7,
-				"Dark": 15,
+				"Dark": 15
 			},
 			"body": {
 				"archetype":"DEMON"

--- a/starts/Default-Verbose.json
+++ b/starts/Default-Verbose.json
@@ -45,6 +45,7 @@
 		{
 			"type":"Angel",
 			"name":"Angel",
+			"start": true,
 			"attributes": {
 				"Power":5,
 				"Seduction":7,
@@ -83,6 +84,7 @@
 		{
 			"type":"Cassie",
 			"name":"Cassie",
+			"start": true,
 			"attributes": {
 				"Power":6,
 				"Seduction":6,
@@ -122,6 +124,7 @@
 		{
 			"type":"Jewel",
 			"name":"Jewel",
+			"start": true,
 			"attributes": {
 				"Power":7,
 				"Seduction":5,

--- a/starts/Default.json
+++ b/starts/Default.json
@@ -6,18 +6,6 @@
 	
 	},
 	"npcs": [
-		{
-			"type":"Angel"
-		},
-		{
-			"type":"Cassie"
-		},
-		{
-			"type":"Jewel"
-		},
-		{
-			"type":"Mara"
-		},
 	],
 	"all_npcs": {
 	

--- a/starts/NewGame+.json
+++ b/starts/NewGame+.json
@@ -8,7 +8,7 @@
 			"Seduction":5,
 			"Cunning":5
 		},
-		"attribute_points": 20
+		"attribute_points": 20,
 		"money": 15000,
 		"traits": [
 			"pussyhandler",
@@ -20,7 +20,7 @@
 	},
 	"npcs": [
 		{
-			"type":"Airi"
+			"type":"Airi",
 			"attributes": {
 				"Power": 6,
 				"Seduction": 17,
@@ -42,7 +42,7 @@
 			]
 		},
 		{
-			"type":"Angel"
+			"type":"Angel",
 			"attributes": {
 				"Power": 13,
 				"Seduction": 20,
@@ -67,7 +67,7 @@
 			]
 		},
 		{
-			"type":"Cassie"
+			"type":"Cassie",
 			"attributes": {
 				"Power": 13,
 				"Seduction": 13,
@@ -93,7 +93,7 @@
 			]
 		},
 		{
-			"type":"Eve"
+			"type":"Eve",
 			"attributes": {
 				"Power": 12,
 				"Seduction": 13,
@@ -110,7 +110,7 @@
 					"pussy":"normal"
 				},
 				"breasts":"d"
-			}
+			},
 			"traits": [
 				"exhibitionist",
 				"insatiable",
@@ -127,7 +127,7 @@
 			]
 		},
 		{
-			"type":"Jewel"
+			"type":"Jewel",
 			"attributes": {
 				"Power": 20,
 				"Seduction": 10,
@@ -152,7 +152,7 @@
 			]
 		},
 		{
-			"type":"Kat"
+			"type":"Kat",
 			"attributes": {
 				"Power": 10,
 				"Seduction": 7,
@@ -179,7 +179,7 @@
 			]
 		},
 		{
-			"type":"Mara"
+			"type":"Mara",
 			"attributes": {
 				"Power": 10,
 				"Seduction": 10,
@@ -207,12 +207,12 @@
 			]
 		},
 		{
-			"type":"Reyka"
+			"type":"Reyka",
 			"attributes": {
 				"Power": 5,
 				"Seduction": 14,
 				"Cunning": 7,
-				"Dark": 5,
+				"Dark": 5
 			},
 			"body": {
 				"archetype":"DEMON"

--- a/starts/NewGame+.json
+++ b/starts/NewGame+.json
@@ -21,6 +21,8 @@
 	"npcs": [
 		{
 			"type":"Airi",
+			"start":true,
+
 			"attributes": {
 				"Power": 6,
 				"Seduction": 17,
@@ -43,6 +45,7 @@
 		},
 		{
 			"type":"Angel",
+			"start":true,
 			"attributes": {
 				"Power": 13,
 				"Seduction": 20,
@@ -68,6 +71,7 @@
 		},
 		{
 			"type":"Cassie",
+			"start":true,
 			"attributes": {
 				"Power": 13,
 				"Seduction": 13,
@@ -94,6 +98,7 @@
 		},
 		{
 			"type":"Eve",
+			"start":true
 			"attributes": {
 				"Power": 12,
 				"Seduction": 13,
@@ -128,6 +133,7 @@
 		},
 		{
 			"type":"Jewel",
+			"start":true
 			"attributes": {
 				"Power": 20,
 				"Seduction": 10,
@@ -153,6 +159,7 @@
 		},
 		{
 			"type":"Kat",
+			"start":true,
 			"attributes": {
 				"Power": 10,
 				"Seduction": 7,
@@ -180,6 +187,7 @@
 		},
 		{
 			"type":"Mara",
+			"start":true,
 			"attributes": {
 				"Power": 10,
 				"Seduction": 10,
@@ -208,6 +216,7 @@
 		},
 		{
 			"type":"Reyka",
+			"start":true,
 			"attributes": {
 				"Power": 5,
 				"Seduction": 14,

--- a/starts/Start Config Description.txt
+++ b/starts/Start Config Description.txt
@@ -17,28 +17,29 @@ player: (All elements are optional)
 	traits			Starting traits. Defaults to an empty list
 	trait_choice    Boolean value. When true, allows the player to pick two starting traits, like normal. If "traits" is specified, these are added to the list. Defaults to true.
 	body			The player's body. If unspecified, defaults to the default body for the player's gender. See below.
-	clothing		The initial clothing. Defaults to standard clothing for the gender.
+	clothing		The initial clothing. Defaults to standard clothing for the character or gender. If set, make sure to specify the complete outfit.
 	
-npcs: List of objects (at least 1) of the following format:
+npcs: List of objects of the following format:
 	type (mandatory)The NPC's type. No more than 1 NPC of each type may be specified.
 	name			The NPC's name. Defaults to the type's standard name.
 	start           Whether the NPC is available at the start of the game. Defaults to false.
 	<all elements from player, except trait_choice. Gender instead defaults to female>
 	
 all_npcs:
+	start           Whether the NPC is available at the start of the game. Defaults to false.
 	<all elements from player, except trait_choice. Gender instead defaults to female>
 	<parameters in all_npcs can be overridden in individual npcs>
 	
 body:
 	<uses the gender's standard body as a base>
-	archetype		One of the advanced classes. This applies things like genital mods, wings, tails and such. Can be overridden by further parameters. Defaults to plain old, pre-lvl10 human. Possible values are regular, succubus, cat, angel, cyborg, witch and slime.
+	archetype		One of the advanced classes. This applies things like genital mods, wings, tails and such. Can be overridden by other body parameters. Possible values are regular, succubus, cat, angel, cyborg, witch and slime. A value of "regular" will reset a character's parts to human.
 	genitals		The body's genitals. If unspecified, use the gender's genitals. If specified, the body will have precisely these genitals, not the default ones.
 	breasts			The breasts. Should be a BreastPart enum constant (a, b, c, d, dd, e, f, g, h, flat). Defaults to flat for male/asex, b for female/herm.
 	ass				The ass. Defaults to the regular ass, the only alternative (currently) is AnalPussy.
 	ears			Defaults to normal, can also be pointed or cat
 	tail			Defaults to none, can also be demonic or cat. (Slimy variations not supported)
 	wings			Defaults to none, can alse be angelic or demonic.
-	tentacles		List of parts to which tentacles should be attached. Defaults to empty. Valid entries are ass, mouth, pussy, hands, feet tail and cock. If you try to hook a tentacle to a part the body doesn't have, that's an error.
+	tentacles		List of parts to which tentacles should be attached. Defaults to empty. Valid entries are ass, mouth, pussy, hands, feet tail and cock. If you try to hook a tentacle to a part the body doesn't have, that's an error. If set, will remove any original tentacles the character had.
 	hotness			Decimal value. Scales temptation damage. Defaults to 1.0	
 
 genitals: (again, both are optional)

--- a/starts/Start Config Description.txt
+++ b/starts/Start Config Description.txt
@@ -22,6 +22,7 @@ player: (All elements are optional)
 npcs: List of objects (at least 1) of the following format:
 	type (mandatory)The NPC's type. No more than 1 NPC of each type may be specified.
 	name			The NPC's name. Defaults to the type's standard name.
+	start           Whether the NPC is available at the start of the game. Defaults to false.
 	<all elements from player, except trait_choice. Gender instead defaults to female>
 	
 all_npcs:

--- a/test_modifier.json
+++ b/test_modifier.json
@@ -42,7 +42,7 @@
 				"clothing" : "jacket"
 			}
 		}
-	]
+	],
 	"item" : [
 		{
 			"type" : "ban-toys",


### PR DESCRIPTION
I discovered Nightgamesmod last week and played version 2.0.3.3 for a few days straight. After trying out a bunch of player builds, I decided to delve into NewGame+. However, I noticed two major problems with all advanced starts: 1) The game was ignoring the way I spent my attribute points on the starting screen, and 2) The NPCs were missing a lot of their usual aspects. Poor Angel lost her glorious boobs and cute outfit!

Long story short, I made a bunch of changes to game creation, character creation, and start configuration management. The philosophy I took with regards to handling start configs is that they represent modifications to the base game, that anything not specified in the config should be left alone (as much as it makes sense to do so), and that if you find yourself trying to completely rewrite a character in a config you should probably just make a custom NPC instead.

If you like what I've done here, I have a lot of free time until July and would be happy to work on any bug fixes or new features you have in mind.

TL;DR: Fixed (maybe) advanced starts, made game and character creation more consistent, and added some rudimentary unit tests.
